### PR TITLE
Create docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,9 +1,12 @@
 name: Build and publish container image
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "main" ]
-
+    paths-ignore:
+    - 'README.md'
+    
 jobs:
 
   build-and-push:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,7 @@
 name: Build and publish container image
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:
@@ -30,4 +30,4 @@ jobs:
         context: ./src
         file: ./src/ServiceBusViewer/Dockerfile
         push: true
-        tags: ghcr.io/${{ github.repository }}:latest
+        tags: ghcr.io/${{ github.repository_owner }}/servicebusviewer:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Build and publish container image
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build-and-push:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./src
+        file: ./src/ServiceBusViewer/Dockerfile
+        push: true
+        tags: ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate the building and publishing of a Docker container image. The workflow is triggered on pull requests to the `main` branch and uses the GitHub Container Registry for storing the built images.

### Key Changes:

#### CI/CD Automation:
* `.github/workflows/docker-image.yml`: Added a new workflow named "Build and publish container image" that includes:
  - Triggering on pull requests to the `main` branch.
  - A `build-and-push` job that checks out the repository, logs into the GitHub Container Registry, builds the Docker image using the specified `Dockerfile`, and pushes the image to the registry with the `latest` tag.