### PR TITLE
Updating repository name

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -33,4 +33,4 @@ jobs:
         context: ./src
         file: ./src/ServiceBusViewer/Dockerfile
         push: true
-        tags: ghcr.io/${{ github.repository_owner.toLowerCase() }}/servicebusviewer:latest
+        tags: ghcr.io/veselovandrey/servicebusviewer:latest


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/build-container-image.yml` file by updating the container image tag to use a specific repository owner.