### PR TITLE
Take connection string from an ENV var

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,23 @@ Or with Podman:
 podman build -f ServiceBusViewer/Dockerfile -t servicebusviewer .
 ```
 
-No special parameters are required to run the container. For example, to run the container using Docker:
+Provide the Service Bus connection string via `SERVICEBUS_CONNECTION_STRING` (recommended). Examples:
+
+Docker:
 ```bash
-docker run --name ServiceBusViewer -p 5000:8080 -d servicebusviewer
+docker run --name ServiceBusViewer -p 5000:8080 \
+	-e SERVICEBUS_CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-d servicebusviewer
 ```
 
-Or using Podman:
+Podman:
 ```bash
-podman run --name ServiceBusViewer -p 5000:8080 -d servicebusviewer
+podman run --name ServiceBusViewer -p 5000:8080 \
+	-e SERVICEBUS_CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-d servicebusviewer
 ```
+
+If `SERVICEBUS_CONNECTION_STRING` is not set, the app falls back to its built-in development emulator connection string.
 
 ### Running from source
 To run the Service Bus Viewer from source, you need to have the following prerequisites installed:

--- a/README.md
+++ b/README.md
@@ -45,23 +45,23 @@ Or with Podman:
 podman build -f ServiceBusViewer/Dockerfile -t servicebusviewer .
 ```
 
-You can provide the Service Bus connection string via `SERVICEBUS_CONNECTION_STRING`. Examples:
+You can provide the Service Bus connection string via `CONNECTION_STRING`. Examples:
 
 Docker:
 ```bash
 docker run --name ServiceBusViewer -p 5000:8080 \
-	-e SERVICEBUS_CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-e CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
 	-d servicebusviewer
 ```
 
 Podman:
 ```bash
 podman run --name ServiceBusViewer -p 5000:8080 \
-	-e SERVICEBUS_CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-e CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
 	-d servicebusviewer
 ```
 
-If `SERVICEBUS_CONNECTION_STRING` is not set, the app falls back to its built-in development emulator connection string.
+If `CONNECTION_STRING` is not set, the app falls back to its built-in development emulator connection string.
 
 ### Running from source
 To run the Service Bus Viewer from source, you need to have the following prerequisites installed:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Or with Podman:
 podman build -f ServiceBusViewer/Dockerfile -t servicebusviewer .
 ```
 
-Provide the Service Bus connection string via `SERVICEBUS_CONNECTION_STRING` (recommended). Examples:
+You can provide the Service Bus connection string via `SERVICEBUS_CONNECTION_STRING`. Examples:
 
 Docker:
 ```bash

--- a/src/ServiceBusViewer/Dockerfile
+++ b/src/ServiceBusViewer/Dockerfile
@@ -3,8 +3,7 @@ USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
-ENV SERVICEBUS_CONNECTION_STRING=""
-
+ENV CONNECTION_STRING=""
 
 # This stage is used to build the service project
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build

--- a/src/ServiceBusViewer/Dockerfile
+++ b/src/ServiceBusViewer/Dockerfile
@@ -3,6 +3,7 @@ USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
 EXPOSE 8081
+ENV SERVICEBUS_CONNECTION_STRING=""
 
 
 # This stage is used to build the service project

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -103,7 +103,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 			return Page();
 		}
 
-		try	{
+		try {
 			DisplayedMessage = await _serviceBusService.PeekMessageAsync(messageId);
 			DisplayType = MessageDisplayType.Peeked;
 
@@ -119,7 +119,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostReceive()
 	{
-		try	{
+		try {
 			DisplayedMessage = await _serviceBusService.ReceiveMessageAsync();
 			DisplayType = MessageDisplayType.Received;
 
@@ -135,14 +135,14 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostSend()
 	{
-		if (string.IsNullOrWhiteSpace(SendMessageBody))	{
+		if (string.IsNullOrWhiteSpace(SendMessageBody)) {
 			ModelState.AddModelError(string.Empty, "Message body cannot be empty.");
 			Messages = await _serviceBusService.PeekMessagesAsync();
 
 			return Page();
 		}
 
-		try	{
+		try {
 			Dictionary<string, object> properties = SendMessageProperties.ToDictionary(x => x.Key, x => (object)x.Value);
 
 			await _serviceBusService.SendMessageAsync(SendMessageBody, "application/json", properties);

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -62,7 +62,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 			return Page();
 		}
 
-		try	{
+		try {
 			_serviceBusService.ConnectTo(ConnectionString, EntityName, SubscriptionName);
 
 			Messages = await _serviceBusService.PeekMessagesAsync();
@@ -85,7 +85,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostRefresh()
 	{
-		try	{
+		try {
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
 		catch (Exception ex) {

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -21,7 +21,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	private readonly ServiceBusService _serviceBusService = serviceBusService;
 
 	[BindProperty(SupportsGet = true)]
-	public string? ConnectionString { get; set; } = Environment.GetEnvironmentVariable("SERVICEBUS_CONNECTION_STRING")
+	public string? ConnectionString { get; set; } = Environment.GetEnvironmentVariable("CONNECTION_STRING")
 		?? "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;"; // Use development connection string by default
 
 	[BindProperty(SupportsGet = true)]
@@ -57,20 +57,17 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostConnect()
 	{
-		if (string.IsNullOrWhiteSpace(ConnectionString) || string.IsNullOrWhiteSpace(EntityName))
-		{
+		if (string.IsNullOrWhiteSpace(ConnectionString) || string.IsNullOrWhiteSpace(EntityName)) {
 			ModelState.AddModelError(string.Empty, "Connection string and Queue/Topic name are required.");
 			return Page();
 		}
 
-		try
-		{
+		try	{
 			_serviceBusService.ConnectTo(ConnectionString, EntityName, SubscriptionName);
 
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Connection failed: {ex.Message}");
 		}
 
@@ -88,12 +85,10 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostRefresh()
 	{
-		try
-		{
+		try	{
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Refresh failed: {ex.Message}");
 		}
 
@@ -103,21 +98,18 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostPeek(string messageId)
 	{
-		if (string.IsNullOrEmpty(MessageId))
-		{
+		if (string.IsNullOrEmpty(MessageId)) {
 			ModelState.AddModelError(string.Empty, "Message ID is required to peek.");
 			return Page();
 		}
 
-		try
-		{
+		try	{
 			DisplayedMessage = await _serviceBusService.PeekMessageAsync(messageId);
 			DisplayType = MessageDisplayType.Peeked;
 
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Peek failed: {ex.Message}");
 		}
 
@@ -127,15 +119,13 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostReceive()
 	{
-		try
-		{
+		try	{
 			DisplayedMessage = await _serviceBusService.ReceiveMessageAsync();
 			DisplayType = MessageDisplayType.Received;
 
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Receive failed: {ex.Message}");
 		}
 
@@ -145,16 +135,14 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostSend()
 	{
-		if (string.IsNullOrWhiteSpace(SendMessageBody))
-		{
+		if (string.IsNullOrWhiteSpace(SendMessageBody))	{
 			ModelState.AddModelError(string.Empty, "Message body cannot be empty.");
 			Messages = await _serviceBusService.PeekMessagesAsync();
 
 			return Page();
 		}
 
-		try
-		{
+		try	{
 			Dictionary<string, object> properties = SendMessageProperties.ToDictionary(x => x.Key, x => (object)x.Value);
 
 			await _serviceBusService.SendMessageAsync(SendMessageBody, "application/json", properties);
@@ -164,8 +152,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 			Messages = await _serviceBusService.PeekMessagesAsync();
 		}
-		catch (Exception ex)
-		{
+		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Send failed: {ex.Message}");
 		}
 


### PR DESCRIPTION
## Problem
- Connection string was hardcoded in `Pages/Index.cshtml.cs`, making container deployments inflexible.
- Docker image lacked an explicit environment variable for the Service Bus connection string, so overrides were clunky.
- When connecting/disconnecting to a queue or topic, the connection string reset, forcing users to re-enter it; juggling multiple entities became error-prone.

## Solution
- `ConnectionString` now reads `SERVICEBUS_CONNECTION_STRING` from the environment, falling back to the previous development default.
- `Dockerfile` declares `ENV SERVICEBUS_CONNECTION_STRING=""` so the value can be injected at build/run time.

## How to Build & Run
- Run (host port 5000 to container 8080 with env):
  ```powershell
  docker run --rm -p 5000:8080 `
    -e SERVICEBUS_CONNECTION_STRING="Endpoint=sb://...;SharedAccessKeyName=...;SharedAccessKey=...;" `
    servicebusviewer:latest
  ```

## Notes
- The legacy dev connection string remains as fallback for local runs without the env var.
- Update the env var value per environment (local, CI, production).