### PR TITLE
Service Bus entity browser: root mode, entity switch UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AI Coding Agent Instructions
+
+## Project Context
+A **temporary, AI-generated** ASP.NET Razor Pages web app for viewing/interacting with Azure Service Bus queues/topics. Primary use case: local development with the [Azure Service Bus Emulator](https://github.com/Azure/azure-service-bus-emulator-installer). No long-term maintenance planned.
+
+## Architecture
+
+### Core Components
+- **[ServiceBusService.cs](src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs)**: Singleton service managing a single persistent `ServiceBusClient` connection. Provides peek/receive/send operations.
+- **[Index.cshtml.cs](src/ServiceBusViewer/Pages/Index.cshtml.cs)**: The only page. Handles all UI interactions via `OnPost*` handlers (Connect, Disconnect, Refresh, Peek, Receive, Send).
+- **Models**: Simple record types ([MessageDetails](src/ServiceBusViewer/Infrastructure/ServiceBus/Models/MessageDetails.cs), [PeekedMessageInfo](src/ServiceBusViewer/Infrastructure/ServiceBus/Models/PeekedMessageInfo.cs)) with no business logic.
+
+### Key Design Patterns
+- **Singleton Service**: `ServiceBusService` is registered as singleton in [Program.cs](src/ServiceBusViewer/Program.cs). Only one connection active at a time.
+- **State Management**: Connection state tracked via `Connected` property + string fields (`Host`, `EntityName`, `SubscriptionName`). No distributed state.
+- **Error Handling**: Exceptions caught in `OnPost*` handlers, added to `ModelState.AddModelError()`, displayed in UI via Razor validation summary.
+
+## Development Workflows
+
+### Running Locally
+```powershell
+cd src\ServiceBusViewer
+dotnet run
+```
+Defaults to `localhost` emulator connection string (see [Index.cshtml.cs#L25-26](src/ServiceBusViewer/Pages/Index.cshtml.cs)).
+
+### Docker Build (from solution directory)
+```powershell
+cd src
+docker build -f ServiceBusViewer/Dockerfile -t servicebusviewer .
+docker run -p 5000:8080 -e CONNECTION_STRING="..." servicebusviewer
+```
+**Critical**: Dockerfile expects to run from `src/` (solution directory), not project directory.
+
+### Connection String Patterns
+- **Emulator from host**: `Endpoint=sb://localhost;SharedAccessKeyName=...;UseDevelopmentEmulator=true;`
+- **Emulator from container**: Use `host.docker.internal` instead of `localhost`
+- See [README.md](README.md#accessing-the-service-bus-emulator) for full examples
+
+## Project-Specific Conventions
+
+### C# Patterns
+- **Records for DTOs**: All model classes use `record` types with positional parameters (e.g., `MessageDetails`, `PeekedMessageInfo`).
+- **XML docs**: Public methods/properties in `ServiceBusService` have `<summary>` tags. Apply same pattern to new public members.
+- **Nullable reference types**: Enabled via `<Nullable>enable</Nullable>`. Use `?` for optional parameters/properties.
+- **Primary constructors**: Page models use C# 12 primary constructors (e.g., `IndexModel(ServiceBusService serviceBusService)`).
+
+### Razor Pages
+- **Single-page app**: All functionality in `Index.cshtml` + code-behind. No navigation/routing beyond root.
+- **Form handlers**: Each action has dedicated `OnPost{Action}` method. Always call `FillHeaderValue()` before returning `Page()`.
+- **Model binding**: Use `[BindProperty]` for form inputs. Use `[BindProperty(SupportsGet = true)]` for query string params.
+
+### Service Bus Client Usage
+- **Receiver disposal**: Always use `await using var receiver = GetReceiver()` for automatic cleanup.
+- **PeekLock mode**: All receivers created with `ServiceBusReceiveMode.PeekLock` (see [ServiceBusService.cs#L148](src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs)).
+- **Queue vs Topic**: `GetReceiver()` auto-detects based on `SubscriptionName` presence. Senders ignore subscriptions (topics only).
+
+## External Dependencies
+- **Azure.Messaging.ServiceBus 7.20.1**: Primary SDK. No custom wrappers/abstractions beyond `ServiceBusService`.
+- **Bootstrap 5.3.6**: Vendored in [wwwroot/lib/bootstrap](src/ServiceBusViewer/wwwroot/lib/bootstrap). No CDN usage.
+- **.NET 10.0**: Targeting `net10.0` framework. Uses implicit usings and file-scoped namespaces.
+
+## Testing & Debugging
+- **No automated tests**: Project has no test projects or test code. Manual testing only.
+- **Launch profiles**: See [launchSettings.json](src/ServiceBusViewer/Properties/launchSettings.json). Use "ServiceBusViewer" for local dev, "Container (Dockerfile)" for Docker testing.
+- **Environment variable**: Set `CONNECTION_STRING` env var to override default connection string.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For more information on running and configuring the Azure Service Bus Emulator, 
 ## Features
 
 - Connect to any Service Bus instance using a connection string.
+- Browse all queues and topics in a namespace using a root connection string.
 - Peek and receive messages from queues or topics.
 - View message details and properties.
 - Send messages to queues or topics.
@@ -45,12 +46,17 @@ Or with Podman:
 podman build -f ServiceBusViewer/Dockerfile -t servicebusviewer .
 ```
 
-You can provide the Service Bus connection string via `CONNECTION_STRING`. Examples:
+You can provide the Service Bus connection string via:
+- **CONNECTION_STRING**: Connects to a specific queue or topic. You must specify the entity name in the UI.
+- **ROOT_CONNECTION_STRING**: Connects with namespace-level permissions, allowing you to browse and select from all available queues and topics. When provided, the entity list is automatically populated, and you can switch between entities without reconnecting.
+
+Example:
 
 Docker:
 ```bash
 docker run --name ServiceBusViewer -p 5000:8080 \
 	-e CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-e ROOT_CONNECTION_STRING="Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
 	-d servicebusviewer
 ```
 
@@ -58,6 +64,7 @@ Podman:
 ```bash
 podman run --name ServiceBusViewer -p 5000:8080 \
 	-e CONNECTION_STRING="Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
+	-e ROOT_CONNECTION_STRING="Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;" \
 	-d servicebusviewer
 ```
 
@@ -94,3 +101,10 @@ Endpoint=sb://localhost:[PORT];SharedAccessKeyName=RootManageSharedAccessKey;Sha
 ```
 Endpoint=sb://host.docker.internal:[PORT];SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
 ```
+
+## Version history
+
+- 0.6.0 (2025-01-31): Add entity selection feature with visual icons for queues, topics, and subscriptions.
+- 0.5.2 (2026-01-24): Take connection string from an environment variable.
+- 0.5.1 (2026-01-22): Update to .NET 10.
+- 0.5.0 (2025-05-26): Initial version of ServiceBusViewer.

--- a/src/ServiceBusViewer.sln
+++ b/src/ServiceBusViewer.sln
@@ -1,12 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.14.36121.58
+# Visual Studio Version 18
+VisualStudioVersion = 18.2.11415.280 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBusViewer", "ServiceBusViewer\ServiceBusViewer.csproj", "{2BFC9B6C-C944-3029-80E8-A28CD620017A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{089100B1-113F-4E66-888A-E83F3999EAFD}"
 	ProjectSection(SolutionItems) = preProject
+		..\AGENTS.md = ..\AGENTS.md
 		..\LICENSE = ..\LICENSE
 		..\README.md = ..\README.md
 	EndProjectSection

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityInfo.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityInfo.cs
@@ -1,0 +1,18 @@
+namespace ServiceBusViewer.Infrastructure.ServiceBus.Models;
+
+/// <summary>Represents information about a Service Bus entity.</summary>
+/// <param name="Name">The name of the entity.</param>
+public abstract record EntityInfo(string Name);
+
+/// <summary>Represents information about a Service Bus queue.</summary>
+/// <param name="Name">The name of the queue.</param>
+public record QueueEntityInfo(string Name) : EntityInfo(Name);
+
+/// <summary>Represents information about a Service Bus topic.</summary>
+/// <param name="Name">The name of the topic.</param>
+public record TopicEntityInfo(string Name) : EntityInfo(Name);
+
+/// <summary>Represents information about a Service Bus topic subscription.</summary>
+/// <param name="Name">The name of the subscription.</param>
+/// <param name="TopicName">The name of the parent topic.</param>
+public record SubscriptionEntityInfo(string Name, string TopicName) : EntityInfo(Name);

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -1,244 +1,306 @@
 @page
+@using ServiceBusViewer.Infrastructure.ServiceBus.Models
 @model ServiceBusViewer.Pages.IndexModel
 @{
-	ViewData["Title"] = "Service Bus Viewer";
+    ViewData["Title"] = "Service Bus Viewer";
 }
 
 @section CSS {
-	<style>
-		.animation-effect {
-			transition: opacity 0.3s ease, max-height 0.3s ease;
-		}
+    <style>
+        .animation-effect {
+            transition: opacity 0.3s ease, max-height 0.3s ease;
+        }
 
-		#sendFormWrapper {
-			opacity: 1;
-			max-height: 1000px;
-			overflow: hidden;
-		}
+        #sendFormWrapper {
+            opacity: 1;
+            max-height: 1000px;
+            overflow: hidden;
+        }
 
-			#sendFormWrapper.js-send-form-hidden {
-				opacity: 0;
-				max-height: 0;
-				pointer-events: none;
-			}
-	</style>
+            #sendFormWrapper.js-send-form-hidden {
+                opacity: 0;
+                max-height: 0;
+                pointer-events: none;
+            }
+    </style>
 }
 
 
 @if (!Model.IsConnected)
 {
-	<form method="post" asp-page-handler="Connect" class="mb-4">
-		@Html.AntiForgeryToken()
-		<div class="mb-3">
-			<label class="form-label">Connection String</label>
-			<input type="text" name="ConnectionString" value="@Model.ConnectionString" class="form-control" required />
-		</div>
-		<div class="mb-3">
-			<label class="form-label">Queue or Topic Name</label>
-			<input type="text" name="EntityName" value="@Model.EntityName" class="form-control" required />
-		</div>
-		<div class="mb-3">
-			<label class="form-label">Subscription (optional)</label>
-			<input type="text" name="SubscriptionName" value="@Model.SubscriptionName" class="form-control" />
-		</div>
-		<button type="submit" class="btn btn-primary">Connect</button>
-	</form>
+    <form method="post" asp-page-handler="Connect" class="mb-4">
+        @Html.AntiForgeryToken()
+        <div class="mb-3">
+            <label class="form-label">Connection String</label>
+            <input type="text" name="ConnectionString" value="@Model.ConnectionString" class="form-control" required />
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Root Connection String (Optional)</label>
+            <input type="text" name="RootConnectionString" value="@Model.RootConnectionString" class="form-control" placeholder="For browsing all entities in namespace" />
+            <small class="form-text text-muted">
+                If provided, allows browsing all queues and topics. Otherwise, connect to specific entity only.
+            </small>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Queue or Topic Name</label>
+            <input type="text" name="EntityName" value="@Model.EntityName" class="form-control" />
+            <small class="form-text text-muted">
+                Required when not using root connection string.
+            </small>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Subscription (optional)</label>
+            <input type="text" name="SubscriptionName" value="@Model.SubscriptionName" class="form-control" />
+        </div>
+        <button type="submit" class="btn btn-primary">Connect</button>
+    </form>
 }
 else
 {
-	@if (Model.Connection is not null) {
-		<div class="d-flex gap-2 mb-3">
-			<span class="small text-muted">
-				Target host: <em>@Model.Connection.Host</em>,
-				@if (Model.SubscriptionName is not null)
-				{
-					@:topic: <em>@Model.Connection.Entity</em>, subscription: <em>@Model.Connection.Subscription</em>
-				}
-				else
-				{
-					@:queue: <em>@Model.Connection.Entity</em>
-				}
-			</span>
-		</div>
-	}
+    @if (Model.Connection is not null) {
+        <div class="d-flex gap-2 mb-3">
+            <span class="small text-muted">
+                Target host: <em>@Model.Connection.Host</em>,
+                @if (Model.SubscriptionName is not null)
+                {
+                    @:topic: <em>@Model.Connection.Entity</em>, subscription: <em>@Model.Connection.Subscription</em>
+                }
+                else
+                {
+                    @:queue: <em>@Model.Connection.Entity</em>
+                }
+            </span>
+        </div>
+    }
 
-	<div class="d-flex gap-2 mb-3">
-		<form method="post" asp-page-handler="Refresh" class="mb-0">
-			@Html.AntiForgeryToken()
-			<button type="submit" class="btn btn-outline-success">Refresh</button>
-		</form>
+    @if (!ViewData.ModelState.IsValid)
+    {
+        <div class="alert alert-danger mt-0 mb-2">
+            @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
+            {
+                <div>@error.ErrorMessage</div>
+            }
+        </div>
+    }
 
-		<form method="post" asp-page-handler="Receive" class="mb-0">
-			@Html.AntiForgeryToken()
-			<button type="submit" class="btn btn-outline-primary">Receive</button>
-		</form>
+    <div class="row" style="height: calc(100vh - 200px);">
+        <!-- Left Panel: Entity List -->
+        <div class="col-md-3 border-end" style="overflow-y: auto; height: 100%;">
+            <h5>Entities</h5>
+            @if (Model.AvailableEntities.Count > 0)
+            {
+                <div class="list-group">
+                    @foreach (var queue in Model.AvailableEntities.OfType<QueueEntityInfo>())
+                    {
+                        <form method="post" asp-page-handler="SelectEntity" class="mb-0">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="SelectedEntityName" value="@queue.Name" />
+                            <input type="hidden" name="SelectedEntityType" value="Queue" />
+                            <button type="submit" class="list-group-item list-group-item-action @(Model.EntityName == queue.Name && Model.SubscriptionName == null ? "active" : "")">
+                                <img src="~/components/entity-list/queue.svg" alt="Queue" class="icon" /> @queue.Name
+                            </button>
+                        </form>
+                    }
 
-		<button type="button" id="toggleSendFormBtn" class="btn btn-outline-secondary">Show Send Message</button>
+                    @foreach (var topic in Model.AvailableEntities.OfType<TopicEntityInfo>())
+                    {
+                    <div>
+                        <div class="list-group-item bg-light">
+                                <img src="~/components/entity-list/topic.svg" alt="Topic" class="icon" /> @topic.Name
+                        </div>
+                            @foreach (var subscription in Model.AvailableEntities.OfType<SubscriptionEntityInfo>().Where(e => e.TopicName == topic.Name))
+                            {
+                                <form method="post" asp-page-handler="SelectEntity" class="mb-0">
+                                    @Html.AntiForgeryToken()
+                                    <input type="hidden" name="SelectedEntityName" value="@subscription.Name" />
+                                    <input type="hidden" name="SelectedEntityType" value="Subscription" />
+                                    <input type="hidden" name="SelectedTopicName" value="@subscription.TopicName" />
+                                    <button type="submit" class="list-group-item list-group-item-action ps-4 @(Model.EntityName == topic.Name && Model.SubscriptionName == subscription.Name ? "active" : "")">
+                                        <img src="~/components/entity-list/subscription.svg" alt="Subscription" class="icon" /> @subscription.Name
+                                    </button>
+                                </form>
+                            }
+                        </div>
+                    }
+                </div>
+            }
+            else
+            {
+                <p class="text-muted">No entities available</p>
+            }
+        </div>
 
-		<form method="post" asp-page-handler="Disconnect" class="mb-0">
-			@Html.AntiForgeryToken()
-			<button type="submit" class="btn btn-outline-danger">Disconnect</button>
-		</form>
-	</div>
+        <!-- Right Panel: Messages and Operations -->
+        <div class="col-md-9" style="overflow-y: auto; height: 100%;">
+            <div class="d-flex gap-2 mb-3">
+                <form method="post" asp-page-handler="Refresh" class="mb-0">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-success">Refresh</button>
+                </form>
 
-	@if (!ViewData.ModelState.IsValid)
-	{
-		<div class="alert alert-danger mt-0 mb-2">
-			@foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors))
-			{
-				<div>@error.ErrorMessage</div>
-			}
-		</div>
-	}
+                <form method="post" asp-page-handler="Receive" class="mb-0">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-primary">Receive</button>
+                </form>
 
-	<div id="sendFormWrapper" class="mt-0 js-send-form-hidden">
-		<form method="post" asp-page-handler="Send" class="mt-0">
-			@Html.AntiForgeryToken()
-			<div class="mb-3">
-				<h3>Send Message (text or JSON)</h3>
-				<textarea name="SendMessageBody" class="form-control" rows="5">@Model.SendMessageBody</textarea>
-			</div>
+                <button type="button" id="toggleSendFormBtn" class="btn btn-outline-secondary">Show Send Message</button>
 
-			<div class="mb-3">
-				<label class="form-label">Message properties</label>
-				<div id="properties-container">
-					@for (int i = 0; i < Model.SendMessageProperties.Count; i++)
-					{
-						<div class="input-group mb-2">
-							<input type="text" name="SendMessageProperties[@i].Key" value="@Model.SendMessageProperties[i].Key" placeholder="Key" />
-							<input type="text" name="SendMessageProperties[@i].Value"value="@Model.SendMessageProperties[i].Value" class="form-control" placeholder="Value" />
-							<button type="button" class="btn btn-outline-danger" onclick="this.parentElement.remove()">×</button>
-						</div>
-					}
-				</div>
-				<button type="button" class="btn btn-outline-secondary btn-sm" onclick="addProperty()">+ Add Property</button>
-			</div>
+                <form method="post" asp-page-handler="Disconnect" class="mb-0">
+                    @Html.AntiForgeryToken()
+                    <button type="submit" class="btn btn-outline-danger">Disconnect</button>
+                </form>
+            </div>
 
-			<button type="submit" class="btn btn-success">Send Message</button>
-		</form>
+            <div id="sendFormWrapper" class="mt-0 js-send-form-hidden">
+                <form method="post" asp-page-handler="Send" class="mt-0">
+                    @Html.AntiForgeryToken()
+                    <div class="mb-3">
+                        <h3>Send Message (text or JSON)</h3>
+                        <textarea name="SendMessageBody" class="form-control" rows="5">@Model.SendMessageBody</textarea>
+                    </div>
 
-		@if (!string.IsNullOrEmpty(Model.SendResultMessage))
-		{
-			<div class="alert alert-success mt-3">@Model.SendResultMessage</div>
-		}
-		<hr />
-	</div>
+                    <div class="mb-3">
+                        <label class="form-label">Message properties</label>
+                        <div id="properties-container">
+                            @for (int i = 0; i < Model.SendMessageProperties.Count; i++)
+                            {
+                                <div class="input-group mb-2">
+                                    <input type="text" name="SendMessageProperties[@i].Key" value="@Model.SendMessageProperties[i].Key" placeholder="Key" />
+                                    <input type="text" name="SendMessageProperties[@i].Value"value="@Model.SendMessageProperties[i].Value" class="form-control" placeholder="Value" />
+                                    <button type="button" class="btn btn-outline-danger" onclick="this.parentElement.remove()">×</button>
+                                </div>
+                            }
+                        </div>
+                        <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addProperty()">+ Add Property</button>
+                    </div>
 
-	<h3>Messages</h3>
-	@if (Model.Messages.Count == 0)
-	{
-		<p>No messages found.</p>
-	}
-	else
-	{
-		<ul class="list-group mb-3">
-			@foreach (var message in Model.Messages) {
-				<li class="list-group-item d-flex justify-content-between align-items-center">
-					<strong>@message.MessageId</strong> - <em>@message.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
-					<form method="post" asp-page-handler="Peek" class="mb-0">
-						@Html.AntiForgeryToken()
-						<input type="hidden" name="MessageId" value="@message.MessageId" />
-						<button type="submit" class="btn btn-sm btn-outline-primary">Peek</button>
-					</form>
-				</li>
-			}
-		</ul>
-	}
+                    <button type="submit" class="btn btn-success">Send Message</button>
+                </form>
 
-	@if (Model.DisplayedMessage != null)
-	{
-		<hr />
-		<div class="mt-2">
-			<h3>@(Model.DisplayType == MessageDisplayType.Peeked ? "Peeked Message" : "Received Message")</h3>
+                @if (!string.IsNullOrEmpty(Model.SendResultMessage))
+                {
+                    <div class="alert alert-success mt-3">@Model.SendResultMessage</div>
+                }
+                <hr />
+            </div>
 
-			<ul class="list-group mb-3">
-				<li class="list-group-item">
-					<strong>Message ID:</strong> @Model.DisplayedMessage.MessageId
-				</li>
-				<li class="list-group-item">
-					<strong>Content Type:</strong> @Model.DisplayedMessage.ContentType
-				</li>
-				<li class="list-group-item">
-					<strong>Enqueued Time:</strong> @Model.DisplayedMessage.EnqueuedTimeUtc.ToLocalTime()
-				</li>
-				<li class="list-group-item">
-					<strong>Body:</strong>
-					<pre class="mt-2 bg-light p-2 rounded">@Model.DisplayedMessage.Body</pre>
-				</li>
-				@if (Model.DisplayedMessage.ApplicationProperties?.Any() == true)
-				{
-					<li class="list-group-item">
-						<strong>Application Properties:</strong>
-						<table class="table table-bordered table-sm mt-2 mb-0">
-							<thead class="table-light">
-								<tr>
-									<th>Key</th>
-									<th>Value</th>
-								</tr>
-							</thead>
-							<tbody>
-								@foreach (var prop in Model.DisplayedMessage.ApplicationProperties)
-								{
-									<tr>
-										<td>@prop.Key</td>
-										<td>@prop.Value</td>
-									</tr>
-								}
-							</tbody>
-						</table>
-					</li>
-				}
-			</ul>
-		</div>
-	}
+            <h3>Messages</h3>
+            @if (Model.Messages.Count == 0)
+            {
+                <p>No messages found.</p>
+            }
+            else
+            {
+                <ul class="list-group mb-3">
+                    @foreach (var message in Model.Messages) {
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <strong>@message.MessageId</strong> - <em>@message.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
+                            <form method="post" asp-page-handler="Peek" class="mb-0">
+                                @Html.AntiForgeryToken()
+                                <input type="hidden" name="MessageId" value="@message.MessageId" />
+                                <button type="submit" class="btn btn-sm btn-outline-primary">Peek</button>
+                            </form>
+                        </li>
+                    }
+                </ul>
+            }
+
+            @if (Model.DisplayedMessage != null)
+            {
+                <hr />
+                <div class="mt-2">
+                    <h3>@(Model.DisplayType == MessageDisplayType.Peeked ? "Peeked Message" : "Received Message")</h3>
+
+                    <ul class="list-group mb-3">
+                        <li class="list-group-item">
+                            <strong>Message ID:</strong> @Model.DisplayedMessage.MessageId
+                        </li>
+                        <li class="list-group-item">
+                            <strong>Content Type:</strong> @Model.DisplayedMessage.ContentType
+                        </li>
+                        <li class="list-group-item">
+                            <strong>Enqueued Time:</strong> @Model.DisplayedMessage.EnqueuedTimeUtc.ToLocalTime()
+                        </li>
+                        <li class="list-group-item">
+                            <strong>Body:</strong>
+                            <pre class="mt-2 bg-light p-2 rounded">@Model.DisplayedMessage.Body</pre>
+                        </li>
+                        @if (Model.DisplayedMessage.ApplicationProperties?.Any() == true)
+                        {
+                            <li class="list-group-item">
+                                <strong>Application Properties:</strong>
+                                <table class="table table-bordered table-sm mt-2 mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Key</th>
+                                            <th>Value</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        @foreach (var prop in Model.DisplayedMessage.ApplicationProperties)
+                                        {
+                                            <tr>
+                                                <td>@prop.Key</td>
+                                                <td>@prop.Value</td>
+                                            </tr>
+                                        }
+                                    </tbody>
+                                </table>
+                            </li>
+                        }
+                    </ul>
+                </div>
+            }
+        </div>
+    </div>
 }
 
 @section Scripts {
-	<script>
-		function addProperty() {
-			const container = document.getElementById('properties-container');
-			const index = container.children.length;
-			const group = document.createElement('div');
-			group.className = 'input-group mb-2';
-			group.innerHTML = `
+    <script>
+        function addProperty() {
+            const container = document.getElementById('properties-container');
+            const index = container.children.length;
+            const group = document.createElement('div');
+            group.className = 'input-group mb-2';
+            group.innerHTML = `
 <input type="text" name="SendMessageProperties[${index}].Key" class="form-control" placeholder="Key" />
 <input type="text" name="SendMessageProperties[${index}].Value" class="form-control" placeholder="Value" />
 <button type="button" class="btn btn-outline-danger" onclick="this.parentElement.remove()">×</button>`;
-			container.appendChild(group);
-		}
+            container.appendChild(group);
+        }
 
-		document.addEventListener('DOMContentLoaded', function () {
-			const sendFormWrapper = document.getElementById('sendFormWrapper');
-			const toggleBtn = document.getElementById('toggleSendFormBtn');
+        document.addEventListener('DOMContentLoaded', function () {
+            const sendFormWrapper = document.getElementById('sendFormWrapper');
+            const toggleBtn = document.getElementById('toggleSendFormBtn');
 
-			if (sendFormWrapper != null && toggleBtn != null) {
-				const storageKey = 'sendFormOpen';
-				let isOpen = localStorage.getItem(storageKey);
-				if (isOpen === null) {
-					isOpen = 'true';
-					localStorage.setItem(storageKey, isOpen);
-				}
-				isOpen = isOpen === 'true';
+            if (sendFormWrapper != null && toggleBtn != null) {
+                const storageKey = 'sendFormOpen';
+                let isOpen = localStorage.getItem(storageKey);
+                if (isOpen === null) {
+                    isOpen = 'true';
+                    localStorage.setItem(storageKey, isOpen);
+                }
+                isOpen = isOpen === 'true';
 
-				function updateFormVisibility() {
-					if (isOpen) {
-						sendFormWrapper.classList.remove('js-send-form-hidden');
-						toggleBtn.textContent = 'Hide Send Message';
-					} else {
-						sendFormWrapper.classList.add('js-send-form-hidden');
-						toggleBtn.textContent = 'Show Send Message';
-					}
-				}
+                function updateFormVisibility() {
+                    if (isOpen) {
+                        sendFormWrapper.classList.remove('js-send-form-hidden');
+                        toggleBtn.textContent = 'Hide Send Message';
+                    } else {
+                        sendFormWrapper.classList.add('js-send-form-hidden');
+                        toggleBtn.textContent = 'Show Send Message';
+                    }
+                }
 
-				updateFormVisibility();
+                updateFormVisibility();
 
-				toggleBtn.addEventListener('click', function () {
-					sendFormWrapper.classList.add('animation-effect');
-					isOpen = !isOpen;
-					localStorage.setItem(storageKey, isOpen);
-					updateFormVisibility();
-				});
-			}
-		});
-	</script>
+                toggleBtn.addEventListener('click', function () {
+                    sendFormWrapper.classList.add('animation-effect');
+                    isOpen = !isOpen;
+                    localStorage.setItem(storageKey, isOpen);
+                    updateFormVisibility();
+                });
+            }
+        });
+    </script>
 }

--- a/src/ServiceBusViewer/Pages/Shared/_Layout.cshtml
+++ b/src/ServiceBusViewer/Pages/Shared/_Layout.cshtml
@@ -7,6 +7,7 @@
 	<meta charset="utf-8" />
 	<title>@title</title>
 	<link rel="stylesheet" href="~/lib/bootstrap/5.3.6/css/bootstrap.min.css" />
+	<link rel="stylesheet" href="~/components/entity-list/styles.css" />
 
 	@await RenderSectionAsync("CSS", required: false)
 	<style>

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -5,7 +5,7 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 
-		<Version>0.5.1</Version>
+		<Version>0.6.0</Version>
 		<Product>ServiceBusViewer</Product>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025 Andrey Veselov</Copyright>

--- a/src/ServiceBusViewer/wwwroot/components/entity-list/queue.svg
+++ b/src/ServiceBusViewer/wwwroot/components/entity-list/queue.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="3" width="18" height="4" rx="1"/>
+  <rect x="3" y="10" width="18" height="4" rx="1"/>
+  <rect x="3" y="17" width="18" height="4" rx="1"/>
+</svg>

--- a/src/ServiceBusViewer/wwwroot/components/entity-list/styles.css
+++ b/src/ServiceBusViewer/wwwroot/components/entity-list/styles.css
@@ -1,0 +1,5 @@
+.icon {
+    width: 24px;
+    height: 24px;
+    vertical-align: middle;
+}

--- a/src/ServiceBusViewer/wwwroot/components/entity-list/subscription.svg
+++ b/src/ServiceBusViewer/wwwroot/components/entity-list/subscription.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+     stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="7" y="3" width="10" height="4" rx="1"/>
+  <path d="M5 10h14l-5 5v4l-4 2v-6z"/>
+</svg>

--- a/src/ServiceBusViewer/wwwroot/components/entity-list/topic.svg
+++ b/src/ServiceBusViewer/wwwroot/components/entity-list/topic.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none"
+		 stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+	<rect x="2" y="2" width="18" height="4" rx="0.3"/>
+	<line x1="11" y1="7" x2="3" y2="13"/>
+	<line x1="11" y1="7" x2="11" y2="13"/>
+	<line x1="11" y1="7" x2="19" y2="13"/>
+	<rect x="2" y="13" width="4" height="4" rx="0.3"/>
+	<rect x="9" y="13" width="4" height="4" rx="0.3"/>
+	<rect x="16" y="13" width="4" height="4" rx="0.3"/>
+</svg>


### PR DESCRIPTION
Add support for connecting with a root (admin) connection string to browse all queues, topics, and subscriptions in the namespace. Introduce new entity model types and a left-panel UI for hierarchical entity selection with SVG icons. Users can now switch between entities without disconnecting. Refactor backend to manage entity lists and selection. Update connection form, improve error handling, and add documentation. Bump version to 0.6.0.