### PR TITLE
Add Aspire AppHost for local ServiceBusViewer testing

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [ "main" ]
-    paths-ignore:
-    - 'README.md'
+    paths:
+    - 'src/ServiceBusViewer/**'
 
 jobs:
 

--- a/src/ServiceBusViewer.AppHost/AppHost.cs
+++ b/src/ServiceBusViewer.AppHost/AppHost.cs
@@ -1,0 +1,41 @@
+using Projects;
+
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
+
+string serviceBusEmulatorManagementConnectionString = $"Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+const string serviceBusEmulatorConnectionString = "Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;";
+
+
+// Add SQL Server (Service Bus Emulator storage)
+const string serviceBusEmulatorSqlServerContainerName = "servicebusviewer-servicebusemulator-storage";
+string sqlPassword = Guid.NewGuid().ToString("D");
+
+IResourceBuilder<ContainerResource> serviceBusEmulatorStorage = builder.AddContainer("servicebusviewer-servicebusemulator-storage", "mcr.microsoft.com/mssql/server:2025-latest")
+	.WithContainerName(serviceBusEmulatorSqlServerContainerName)
+	.WithEnvironment("ACCEPT_EULA", "Y")
+	.WithEnvironment("MSSQL_SA_PASSWORD", sqlPassword);
+
+// Add Azure Service Bus emulator
+IResourceBuilder<ContainerResource> serviceBusEmulator = builder.AddContainer("servicebusviewer-servicebusemulator", "mcr.microsoft.com/azure-messaging/servicebus-emulator", "2.0.0")
+	.WithContainerName("servicebusviewer-servicebusemulator")
+	.WaitFor(serviceBusEmulatorStorage, WaitBehavior.WaitOnResourceUnavailable)
+	.WithEndpoint(port: 5672, targetPort: 5672)
+	.WithHttpEndpoint(port: 5300, targetPort: 5300)
+	.WithBindMount(
+		source: "ServiceBusConfig.json",
+		target: "/ServiceBus_Emulator/ConfigFiles/Config.json",
+		isReadOnly: true)
+	.WithHttpHealthCheck("/health")
+	.WithEnvironment("SQL_SERVER", serviceBusEmulatorSqlServerContainerName)
+	.WithEnvironment("MSSQL_SA_PASSWORD", sqlPassword)
+	.WithEnvironment("ACCEPT_EULA", "Y");
+
+// Add Service Bus Viewer
+IResourceBuilder<ProjectResource> serviceBusViewer = builder.AddProject<ServiceBusViewer>("ServiceBusViewer")
+	.WithEnvironment("CONNECTION_STRING", serviceBusEmulatorConnectionString)
+	.WithEnvironment("ROOT_CONNECTION_STRING", serviceBusEmulatorManagementConnectionString)
+	.WaitFor(serviceBusEmulator, WaitBehavior.WaitOnResourceUnavailable);
+
+DistributedApplication app = builder.Build();
+
+await app.RunAsync();

--- a/src/ServiceBusViewer.AppHost/Properties/launchSettings.json
+++ b/src/ServiceBusViewer.AppHost/Properties/launchSettings.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17237;http://localhost:15074",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21196",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23257",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22029",
+        "ASPIRE_DASHBOARD_TELEMETRY_OPTOUT": "true"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15074",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19252",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18216",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20233",
+        "ASPIRE_DASHBOARD_TELEMETRY_OPTOUT": "true"
+      }
+    }
+  }
+}

--- a/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
+++ b/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
@@ -1,0 +1,232 @@
+{
+  "userConfig": {
+    "namespaces": [
+      {
+
+        "name": "sbemulatorns",
+
+        "queues": [
+          {
+            "name": "queue1",
+            "properties": {
+              "lockDuration": "PT5M",
+              "requiresDuplicateDetection": false,
+              "requiresSession": false,
+              "defaultMessageTimeToLive": "PT1H",
+              "deadLetteringOnMessageExpiration": true,
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "maxDeliveryCount": 10,
+              "status": "Active"
+            }
+          },
+
+          {
+            "name": "queue2-with-session",
+            "properties": {
+              "lockDuration": "PT5M",
+              "requiresDuplicateDetection": false,
+              "requiresSession": true,
+              "defaultMessageTimeToLive": "PT1H",
+              "deadLetteringOnMessageExpiration": true,
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "maxDeliveryCount": 10,
+              "status": "Active"
+            }
+          }
+        ],
+
+        "Topics": [
+          {
+            "name": "topic1",
+            "properties": {
+              "requiresDuplicateDetection": false,
+              "requiresSession": false,
+              "defaultMessageTimeToLive": "PT1H",
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "status": "Active"
+            },
+            "Subscriptions": [
+              {
+                "Name": "topic1-subscription1",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": false,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic1-subscription1-filter",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group = 1"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "topic1-subscription2",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": false,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic1-subscription2-filter",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group = 2"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "topic1-subscription-catch",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": false,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic1-catch-all",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group > 2"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+
+          {
+            "name": "topic2-with-session",
+            "properties": {
+              "requiresDuplicateDetection": false,
+              "requiresSession": true,
+              "defaultMessageTimeToLive": "PT1H",
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "status": "Active"
+            },
+            "Subscriptions": [
+              {
+                "Name": "topic2-subscription1",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": true,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic2-subscription1-filter",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group = 1"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "topic2-subscription2",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": true,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic2-subscription2-filter",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group = 2"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "topic2-subscription-catch",
+                "Properties": {
+                  "lockDuration": "PT5M",
+                  "requiresDuplicateDetection": false,
+                  "requiresSession": true,
+                  "defaultMessageTimeToLive": "PT1H",
+                  "deadLetteringOnMessageExpiration": true,
+                  "enableBatchedOperations": true,
+                  "duplicateDetectionHistoryTimeWindow": "PT5M",
+                  "maxDeliveryCount": 10,
+                  "status": "Active"
+                },
+                "rules": [
+                  {
+                    "name": "topic2-catch-all",
+                    "properties": {
+                      "filterType": "Sql",
+                      "sqlFilter": {
+                        "sqlExpression": "group > 2"
+                      },
+                      "action": {}
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+
+    "logging": {
+      "type": "File"
+    }
+  }
+}

--- a/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
+++ b/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net10.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<UserSecretsId>3e4f8198-1258-4c3f-8be5-6de3d7a005b1</UserSecretsId>
+
+		<Product>ServiceBusViewer</Product>
+		<Authors>Andrey Veselov</Authors>
+		<Copyright>Copyright © 2026 Andrey Veselov</Copyright>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\ServiceBusViewer\ServiceBusViewer.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/ServiceBusViewer.AppHost/appsettings.Development.json
+++ b/src/ServiceBusViewer.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/ServiceBusViewer.AppHost/appsettings.json
+++ b/src/ServiceBusViewer.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/src/ServiceBusViewer.sln
+++ b/src/ServiceBusViewer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11415.280 d18.0
+VisualStudioVersion = 18.2.11415.280
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBusViewer", "ServiceBusViewer\ServiceBusViewer.csproj", "{2BFC9B6C-C944-3029-80E8-A28CD620017A}"
 EndProject
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\LICENSE = ..\LICENSE
 		..\README.md = ..\README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceBusViewer.AppHost", "ServiceBusViewer.AppHost\ServiceBusViewer.AppHost.csproj", "{87401ACB-DBC3-4584-ADD7-7B8726FE0BEE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -22,6 +24,10 @@ Global
 		{2BFC9B6C-C944-3029-80E8-A28CD620017A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2BFC9B6C-C944-3029-80E8-A28CD620017A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2BFC9B6C-C944-3029-80E8-A28CD620017A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87401ACB-DBC3-4584-ADD7-7B8726FE0BEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87401ACB-DBC3-4584-ADD7-7B8726FE0BEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87401ACB-DBC3-4584-ADD7-7B8726FE0BEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87401ACB-DBC3-4584-ADD7-7B8726FE0BEE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduced ServiceBusViewer.AppHost project to enable Aspire-based orchestration of local Azure Service Bus emulator and SQL Server storage. Added custom ServiceBusConfig.json for emulator setup, launch settings, and app configuration files for development and logging. Updated solution to include AppHost and project references.