### PR TITLE
Feature/support application property types

### DIFF
--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/ApplicationProperty.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/ApplicationProperty.cs
@@ -1,0 +1,4 @@
+namespace ServiceBusViewer.Infrastructure.ServiceBus.Models;
+
+/// <summary>Represents a user-provided application property for a Service Bus message.</summary>
+public sealed record ApplicationProperty(string Key, string Value, ApplicationPropertyType Type = ApplicationPropertyType.String);

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/ApplicationPropertyType.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/ApplicationPropertyType.cs
@@ -1,0 +1,24 @@
+namespace ServiceBusViewer.Infrastructure.ServiceBus.Models;
+
+/// <summary>Supported application property types for Service Bus messages.</summary>
+public enum ApplicationPropertyType
+{
+	String = 0,
+	Bool,
+	Byte,
+	SByte,
+	Short,
+	UShort,
+	Int,
+	UInt,
+	Long,
+	ULong,
+	Float,
+	Double,
+	Decimal,
+	Char,
+	Guid,
+	DateTime,
+	DateTimeOffset,
+	TimeSpan
+}

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
@@ -1,5 +1,6 @@
 namespace ServiceBusViewer.Infrastructure.ServiceBus;
 
+using System.Globalization;
 using Azure.Messaging.ServiceBus;
 using Azure.Messaging.ServiceBus.Administration;
 using ServiceBusViewer.Infrastructure.ServiceBus.Models;
@@ -195,7 +196,7 @@ public class ServiceBusService
 	/// <param name="content">The message content.</param>
 	/// <param name="messageProperties">The optional system properties to include with the message.</param>
 	/// <param name="applicationProperties">The application properties to include with the message.</param>
-	public async Task SendMessageAsync(string content, MessageProperties? messageProperties, Dictionary<string, object> applicationProperties)
+	public async Task SendMessageAsync(string content, MessageProperties? messageProperties, IReadOnlyList<ApplicationProperty> applicationProperties)
 	{
 		await using ServiceBusSender sender = GetSender();
 
@@ -221,12 +222,37 @@ public class ServiceBusService
 				message.TimeToLive = messageProperties.TimeToLive.Value;
 		}
 
-		foreach (KeyValuePair<string, object> property in applicationProperties) {
+		foreach (ApplicationProperty property in applicationProperties) {
 			if (!string.IsNullOrEmpty(property.Key))
-				message.ApplicationProperties[property.Key] = property.Value;
+				message.ApplicationProperties[property.Key] = ConvertApplicationPropertyValue(property.Value, property.Type);
 		}
 
 		await sender.SendMessageAsync(message);
+	}
+
+	internal static object ConvertApplicationPropertyValue(string value, ApplicationPropertyType type)
+	{
+		return type switch {
+			ApplicationPropertyType.String => value,
+			ApplicationPropertyType.Bool => bool.Parse(value),
+			ApplicationPropertyType.Byte => byte.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.SByte => sbyte.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Short => short.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.UShort => ushort.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Int => int.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.UInt => uint.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Long => long.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.ULong => ulong.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Float => float.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Double => double.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Decimal => decimal.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Char => value.Length == 1 ? value[0] : throw new FormatException("Char value must be a single character."),
+			ApplicationPropertyType.Guid => Guid.Parse(value),
+			ApplicationPropertyType.DateTime => DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+			ApplicationPropertyType.DateTimeOffset => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+			ApplicationPropertyType.TimeSpan => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
+			_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported application property type.")
+		};
 	}
 
 	/// <summary>Gets a <see cref="ServiceBusReceiver"/> for the current entity and subscription.</summary>

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -2,258 +2,258 @@
 @using ServiceBusViewer.Pages.Shared
 @model ServiceBusViewer.Pages.IndexModel
 @{
-    ViewData["Title"] = "Service Bus Viewer";
-    ViewData["ServiceBusHostName"] = Model.ServiceBusHostName;
+	ViewData["Title"] = "Service Bus Viewer";
+	ViewData["ServiceBusHostName"] = Model.ServiceBusHostName;
 }
 
 @section CSS {
-    <style>
-        .animation-effect {
-            transition: opacity 0.3s ease, max-height 0.3s ease;
-        }
+	<style>
+		.animation-effect {
+			transition: opacity 0.3s ease, max-height 0.3s ease;
+		}
 
-        #sendFormWrapper {
-            opacity: 1;
-            max-height: 1000px;
-            overflow: hidden;
-        }
+		#sendFormWrapper {
+			opacity: 1;
+			max-height: 1000px;
+			overflow: hidden;
+		}
 
-            #sendFormWrapper.js-send-form-hidden {
-                opacity: 0;
-                max-height: 0;
-                pointer-events: none;
-            }
-    </style>
+			#sendFormWrapper.js-send-form-hidden {
+				opacity: 0;
+				max-height: 0;
+				pointer-events: none;
+			}
+	</style>
 }
 
 
 @if (!ViewData.ModelState.IsValid) {
-    <div class="alert alert-danger mt-0 mb-2">
-        @foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors)) {
-            <div>@error.ErrorMessage</div>
-        }
-    </div>
+	<div class="alert alert-danger mt-0 mb-2">
+		@foreach (var error in ViewData.ModelState.Values.SelectMany(v => v.Errors)) {
+			<div>@error.ErrorMessage</div>
+		}
+	</div>
 }
 
 <div class="row" style="height: calc(100vh - 200px);">
-    <!-- Left Panel: Entity List -->
-    @await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityName, Model.SubscriptionName, Model.IsManagementApiAvailable))
+	<!-- Left Panel: Entity List -->
+	@await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityName, Model.SubscriptionName, Model.IsManagementApiAvailable))
 
-    <!-- Right Panel: Messages and Operations -->
-    <div class="col-md-9" style="overflow-y: auto; height: 100%;">
-        <div class="d-flex gap-2 mb-3">
-            <form method="post" asp-page-handler="Refresh" class="mb-0" id="refreshForm">
-                @Html.AntiForgeryToken()
-                <button type="submit" class="btn btn-outline-success" id="refreshSubmitBtn">Refresh</button>
-            </form>
+	<!-- Right Panel: Messages and Operations -->
+	<div class="col-md-9" style="overflow-y: auto; height: 100%;">
+		<div class="d-flex gap-2 mb-3">
+			<form method="post" asp-page-handler="Refresh" class="mb-0" id="refreshForm">
+				@Html.AntiForgeryToken()
+				<button type="submit" class="btn btn-outline-success" id="refreshSubmitBtn">Refresh</button>
+			</form>
 
-            <form method="post" asp-page-handler="Receive" class="mb-0" id="receiveForm">
-                @Html.AntiForgeryToken()
-                <button type="submit" class="btn btn-outline-primary" id="receiveSubmitBtn">Receive</button>
-            </form>
+			<form method="post" asp-page-handler="Receive" class="mb-0" id="receiveForm">
+				@Html.AntiForgeryToken()
+				<button type="submit" class="btn btn-outline-primary" id="receiveSubmitBtn">Receive</button>
+			</form>
 
-            <button type="button" id="toggleSendFormBtn" class="btn btn-outline-secondary">Show Send Message</button>
+			<button type="button" id="toggleSendFormBtn" class="btn btn-outline-secondary">Show Send Message</button>
 
-            <form method="post" asp-page-handler="Disconnect" class="mb-0" id="disconnectForm">
-                @Html.AntiForgeryToken()
-                <button type="submit" class="btn btn-outline-danger" id="disconnectSubmitBtn">Disconnect</button>
-            </form>
-        </div>
+			<form method="post" asp-page-handler="Disconnect" class="mb-0" id="disconnectForm">
+				@Html.AntiForgeryToken()
+				<button type="submit" class="btn btn-outline-danger" id="disconnectSubmitBtn">Disconnect</button>
+			</form>
+		</div>
 
-        <div id="sendFormWrapper" class="mt-0 js-send-form-hidden">
-            <form method="post" asp-page-handler="Send" class="mt-0" id="sendMessageForm">
-                @Html.AntiForgeryToken()
-                <div class="mb-3">
-                    <h3>Send Message (text or JSON)</h3>
-                    <textarea name="SendMessageBody" class="form-control" rows="5">@Model.SendMessageBody</textarea>
-                </div>
+		<div id="sendFormWrapper" class="mt-0 js-send-form-hidden">
+			<form method="post" asp-page-handler="Send" class="mt-0" id="sendMessageForm">
+				@Html.AntiForgeryToken()
+				<div class="mb-3">
+					<h3>Send Message (text or JSON)</h3>
+					<textarea name="SendMessageBody" class="form-control" rows="5">@Model.SendMessageBody</textarea>
+				</div>
 
-                <div class="mb-3">
-                    <label class="form-label"><strong>Properties</strong></label>
-                    <div class="row g-2">
-                        <div class="col-md-4">
-                            <label class="form-label">Message ID</label>
-                            <input type="text" name="SendMessageProperties.MessageId" value="@Model.SendMessageProperties.MessageId" maxlength="128" class="form-control" />
-                        </div>
-                        <div class="col-md-4">
-                            <label class="form-label">Session ID</label>
-                            <input type="text" name="SendMessageProperties.SessionId" value="@Model.SendMessageProperties.SessionId" maxlength="128" class="form-control" />
-                        </div>
-                        <div class="col-md-4">
-                            <label class="form-label">Correlation ID</label>
-                            <input type="text" name="SendMessageProperties.CorrelationId" value="@Model.SendMessageProperties.CorrelationId" maxlength="128" class="form-control" />
-                        </div>
-                        <div class="col-md-4">
-                            <label class="form-label">Content Type</label>
-                            <input type="text" name="SendMessageProperties.ContentType" value="@Model.SendMessageProperties.ContentType" class="form-control" />
-                        </div>
-                    </div>
-                    <div class="row g-2 mt-1">
-                        <div class="col-md-6">
-                            <label class="form-label">Scheduled Enqueue Time</label>
-                            <input type="datetime-local" name="SendMessageProperties.ScheduledEnqueueTime" value="@Model.SendMessageProperties.ScheduledEnqueueTime?.ToString("yyyy-MM-ddTHH:mm")" class="form-control" />
-                        </div>
-                        <div class="col-md-6">
-                            <label class="form-label">Time To Live</label>
-                            <input type="text" name="SendMessageProperties.TimeToLive" value="@Model.SendMessageProperties.TimeToLive" placeholder="hh:mm:ss" class="form-control" />
-                        </div>
-                    </div>
-                </div>
+				<div class="mb-3">
+					<label class="form-label"><strong>Properties</strong></label>
+					<div class="row g-2">
+						<div class="col-md-4">
+							<label class="form-label">Message ID</label>
+							<input type="text" name="SendMessageProperties.MessageId" value="@Model.SendMessageProperties.MessageId" maxlength="128" class="form-control" />
+						</div>
+						<div class="col-md-4">
+							<label class="form-label">Session ID</label>
+							<input type="text" name="SendMessageProperties.SessionId" value="@Model.SendMessageProperties.SessionId" maxlength="128" class="form-control" />
+						</div>
+						<div class="col-md-4">
+							<label class="form-label">Correlation ID</label>
+							<input type="text" name="SendMessageProperties.CorrelationId" value="@Model.SendMessageProperties.CorrelationId" maxlength="128" class="form-control" />
+						</div>
+						<div class="col-md-4">
+							<label class="form-label">Content Type</label>
+							<input type="text" name="SendMessageProperties.ContentType" value="@Model.SendMessageProperties.ContentType" class="form-control" />
+						</div>
+					</div>
+					<div class="row g-2 mt-1">
+						<div class="col-md-6">
+							<label class="form-label">Scheduled Enqueue Time</label>
+							<input type="datetime-local" name="SendMessageProperties.ScheduledEnqueueTime" value="@Model.SendMessageProperties.ScheduledEnqueueTime?.ToString("yyyy-MM-ddTHH:mm")" class="form-control" />
+						</div>
+						<div class="col-md-6">
+							<label class="form-label">Time To Live</label>
+							<input type="text" name="SendMessageProperties.TimeToLive" value="@Model.SendMessageProperties.TimeToLive" placeholder="hh:mm:ss" class="form-control" />
+						</div>
+					</div>
+				</div>
 
-                <div class="mb-3">
-                    <label class="form-label"><strong>Application properties</strong></label>
-                    <div id="properties-container">
+				<div class="mb-3">
+					<label class="form-label"><strong>Application properties</strong></label>
+					<div id="properties-container">
 						@for (int i = 0; i < Model.SendMessageApplicationProperties.Count; i++) {
-                            <div class="input-group mb-2">
-                                <input type="text" name="SendMessageApplicationProperties[@i].Key" value="@Model.SendMessageApplicationProperties[i].Key" placeholder="Key" />
+							<div class="input-group mb-2">
+								<input type="text" name="SendMessageApplicationProperties[@i].Key" value="@Model.SendMessageApplicationProperties[i].Key" placeholder="Key" />
 								<select name="SendMessageApplicationProperties[@i].Type" class="form-select" style="max-width: 180px;">
 									@foreach (var type in Enum.GetValues<ServiceBusViewer.Infrastructure.ServiceBus.Models.ApplicationPropertyType>()) {
 										<option value="@type" selected="@(type == Model.SendMessageApplicationProperties[i].Type)">@type</option>
 									}
 								</select>
 								<input type="text" name="SendMessageApplicationProperties[@i].Value" value="@Model.SendMessageApplicationProperties[i].Value" class="form-control" placeholder="Value" />
-                                <button type="button" class="btn btn-outline-danger">×</button>
-                            </div>
-                        }
-                    </div>
-                    <button type="button" class="btn btn-outline-secondary btn-sm" onclick="addProperty()">+ Add Property</button>
-                </div>
+								<button type="button" class="btn btn-outline-danger">×</button>
+							</div>
+						}
+					</div>
+					<button type="button" class="btn btn-outline-secondary btn-sm" onclick="addProperty()">+ Add Property</button>
+				</div>
 
-                <button type="submit" class="btn btn-success" id="sendMessageSubmitBtn">Send Message</button>
-            </form>
+				<button type="submit" class="btn btn-success" id="sendMessageSubmitBtn">Send Message</button>
+			</form>
 
-            @if (!string.IsNullOrEmpty(Model.SendResultMessage)) {
-                <div class="alert alert-success mt-3">@Model.SendResultMessage</div>
-            }
-            <hr />
-        </div>
+			@if (!string.IsNullOrEmpty(Model.SendResultMessage)) {
+				<div class="alert alert-success mt-3">@Model.SendResultMessage</div>
+			}
+			<hr />
+		</div>
 
-        @if (Model.DisplayedMessage is not null) {
-            <div class="mt-2 mb-3">
-                <h3>Received Message</h3>
+		@if (Model.DisplayedMessage is not null) {
+			<div class="mt-2 mb-3">
+				<h3>Received Message</h3>
 
-                <li class="list-group-item">
-                    <strong>Properties:</strong>
-                    <table class="table table-sm mt-0 mb-2">
-                        <tbody>
-                            <tr><td class="w-25">Message ID:</td><td>@Model.DisplayedMessage.Properties.MessageId</td></tr>
-                            <tr><td>Enqueued Time:</td><td>@Model.DisplayedMessage.Properties.EnqueuedTimeUtc.ToLocalTime()</td></tr>
-                            @if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.SessionId)) {
-                                <tr><td>Session ID:</td><td>@Model.DisplayedMessage.Properties.SessionId</td></tr>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.PartitionKey)) {
-                                <tr><td>Partition Key:</td><td>@Model.DisplayedMessage.Properties.PartitionKey</td></tr>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.CorrelationId)) {
-                                <tr><td>Correlation ID:</td><td>@Model.DisplayedMessage.Properties.CorrelationId</td></tr>
-                            }
-                            @if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.ContentType)) {
-                                <tr><td>Content Type:</td><td>@Model.DisplayedMessage.Properties.ContentType</td></tr>
-                            }
-                            @if (Model.DisplayedMessage.Properties.ScheduledEnqueueTime is not null) {
-                                <tr><td>Scheduled Enqueue Time:</td><td>@Model.DisplayedMessage.Properties.ScheduledEnqueueTime?.ToLocalTime()</td></tr>
-                            }
-                            @if (Model.DisplayedMessage.Properties.TimeToLive is not null) {
-                                <tr><td>Time To Live:</td><td>@Model.DisplayedMessage.Properties.TimeToLive</td></tr>
-                            }
-                        </tbody>
-                    </table>
+				<li class="list-group-item">
+					<strong>Properties:</strong>
+					<table class="table table-sm mt-0 mb-2">
+						<tbody>
+							<tr><td class="w-25">Message ID:</td><td>@Model.DisplayedMessage.Properties.MessageId</td></tr>
+							<tr><td>Enqueued Time:</td><td>@Model.DisplayedMessage.Properties.EnqueuedTimeUtc.ToLocalTime()</td></tr>
+							@if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.SessionId)) {
+								<tr><td>Session ID:</td><td>@Model.DisplayedMessage.Properties.SessionId</td></tr>
+							}
+							@if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.PartitionKey)) {
+								<tr><td>Partition Key:</td><td>@Model.DisplayedMessage.Properties.PartitionKey</td></tr>
+							}
+							@if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.CorrelationId)) {
+								<tr><td>Correlation ID:</td><td>@Model.DisplayedMessage.Properties.CorrelationId</td></tr>
+							}
+							@if (!string.IsNullOrWhiteSpace(Model.DisplayedMessage.Properties.ContentType)) {
+								<tr><td>Content Type:</td><td>@Model.DisplayedMessage.Properties.ContentType</td></tr>
+							}
+							@if (Model.DisplayedMessage.Properties.ScheduledEnqueueTime is not null) {
+								<tr><td>Scheduled Enqueue Time:</td><td>@Model.DisplayedMessage.Properties.ScheduledEnqueueTime?.ToLocalTime()</td></tr>
+							}
+							@if (Model.DisplayedMessage.Properties.TimeToLive is not null) {
+								<tr><td>Time To Live:</td><td>@Model.DisplayedMessage.Properties.TimeToLive</td></tr>
+							}
+						</tbody>
+					</table>
 
-                    @if (Model.DisplayedMessage.ApplicationProperties?.Any() == true) {
-                        <strong>Application Properties:</strong>
-                        <table class="table table-sm mt-0 mb-2">
-                            <tbody>
-                                @foreach (var prop in Model.DisplayedMessage.ApplicationProperties) {
-                                    <tr><td>@prop.Key</td><td>@prop.Value</td></tr>
-                                }
-                            </tbody>
-                        </table>
-                    }
+					@if (Model.DisplayedMessage.ApplicationProperties?.Any() == true) {
+						<strong>Application Properties:</strong>
+						<table class="table table-sm mt-0 mb-2">
+							<tbody>
+								@foreach (var prop in Model.DisplayedMessage.ApplicationProperties) {
+									<tr><td>@prop.Key</td><td>@prop.Value</td></tr>
+								}
+							</tbody>
+						</table>
+					}
 
-                    <strong>Body:</strong>
-                    <pre class="mt-0 bg-light p-2 rounded">@Model.DisplayedMessage.Body</pre>
-                    <hr />
-            </div>
-        }
+					<strong>Body:</strong>
+					<pre class="mt-0 bg-light p-2 rounded">@Model.DisplayedMessage.Body</pre>
+					<hr />
+			</div>
+		}
 
-        <h3>Peeked messages @(Model.HasMoreMessages ? $"(first {Model.Messages.Count})" : $"({Model.Messages.Count} total)")</h3>
-        @if (Model.Messages.Count == 0) {
-            <p>No messages found.</p>
-        }
-        else {
-            <ul class="list-group mb-3">
-                @foreach (var message in Model.Messages) {
-                    <li class="list-group-item">
-                        <div class="d-flex justify-content-between align-items-center">
-                            <div>
-                                <strong>@message.Properties.MessageId</strong> - <em>@message.Properties.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
-                            </div>
-                            <button type="button" class="btn btn-sm btn-outline-primary js-toggle-message" data-message-id="@message.Properties.MessageId">
-                                <span class="js-expand-text">▼ Expand</span>
-                                <span class="js-collapse-text" style="display: none;">▲ Collapse</span>
-                            </button>
-                        </div>
-                        <div class="js-message-details mt-3" data-message-id="@message.Properties.MessageId" style="display: none;">
-                            <strong>Properties:</strong>
-                            <table class="table table-sm mt-0 mb-2">
-                                <tbody>
-                                    <tr><td class="w-25">Message ID:</td><td>@message.Properties.MessageId</td></tr>
-                                    <tr><td>Enqueued Time:</td><td>@message.Properties.EnqueuedTimeUtc.ToLocalTime()</td></tr>
+		<h3>Peeked messages @(Model.HasMoreMessages ? $"(first {Model.Messages.Count})" : $"({Model.Messages.Count} total)")</h3>
+		@if (Model.Messages.Count == 0) {
+			<p>No messages found.</p>
+		}
+		else {
+			<ul class="list-group mb-3">
+				@foreach (var message in Model.Messages) {
+					<li class="list-group-item">
+						<div class="d-flex justify-content-between align-items-center">
+							<div>
+								<strong>@message.Properties.MessageId</strong> - <em>@message.Properties.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
+							</div>
+							<button type="button" class="btn btn-sm btn-outline-primary js-toggle-message" data-message-id="@message.Properties.MessageId">
+								<span class="js-expand-text">▼ Expand</span>
+								<span class="js-collapse-text" style="display: none;">▲ Collapse</span>
+							</button>
+						</div>
+						<div class="js-message-details mt-3" data-message-id="@message.Properties.MessageId" style="display: none;">
+							<strong>Properties:</strong>
+							<table class="table table-sm mt-0 mb-2">
+								<tbody>
+									<tr><td class="w-25">Message ID:</td><td>@message.Properties.MessageId</td></tr>
+									<tr><td>Enqueued Time:</td><td>@message.Properties.EnqueuedTimeUtc.ToLocalTime()</td></tr>
 
-                                    @if (!string.IsNullOrWhiteSpace(message.Properties.SessionId)) {
-                                        <tr><td>Session ID:</td><td>@message.Properties.SessionId</td></tr>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(message.Properties.PartitionKey)) {
-                                        <tr><td>Partition Key:</td><td>@message.Properties.PartitionKey</td></tr>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(message.Properties.CorrelationId)) {
-                                        <tr><td>Correlation ID:</td><td>@message.Properties.CorrelationId</td></tr>
-                                    }
-                                    @if (!string.IsNullOrWhiteSpace(message.Properties.ContentType)) {
-                                        <tr><td>Content Type:</td><td>@message.Properties.ContentType</td></tr>
-                                    }
-                                    @if (message.Properties.TimeToLive is not null) {
-                                        <tr><td>Time To Live:</td><td>@message.Properties.TimeToLive</td></tr>
-                                    }
-                                    @if (message.Properties.ScheduledEnqueueTime is not null) {
-                                        <tr><td>Scheduled Enqueue Time:</td><td>@message.Properties.ScheduledEnqueueTime</td></tr>
-                                    }
-                                </tbody>
-                            </table>
+									@if (!string.IsNullOrWhiteSpace(message.Properties.SessionId)) {
+										<tr><td>Session ID:</td><td>@message.Properties.SessionId</td></tr>
+									}
+									@if (!string.IsNullOrWhiteSpace(message.Properties.PartitionKey)) {
+										<tr><td>Partition Key:</td><td>@message.Properties.PartitionKey</td></tr>
+									}
+									@if (!string.IsNullOrWhiteSpace(message.Properties.CorrelationId)) {
+										<tr><td>Correlation ID:</td><td>@message.Properties.CorrelationId</td></tr>
+									}
+									@if (!string.IsNullOrWhiteSpace(message.Properties.ContentType)) {
+										<tr><td>Content Type:</td><td>@message.Properties.ContentType</td></tr>
+									}
+									@if (message.Properties.TimeToLive is not null) {
+										<tr><td>Time To Live:</td><td>@message.Properties.TimeToLive</td></tr>
+									}
+									@if (message.Properties.ScheduledEnqueueTime is not null) {
+										<tr><td>Scheduled Enqueue Time:</td><td>@message.Properties.ScheduledEnqueueTime</td></tr>
+									}
+								</tbody>
+							</table>
 
-                            @if (message.ApplicationProperties?.Any() == true) {
-                                <strong>Application Properties:</strong>
-                                <table class="table table-sm mt-0 mb-2">
-                                    <tbody>
-                                        @foreach (var prop in message.ApplicationProperties) {
-                                            <tr>
-                                                <td class="w-25">@prop.Key</td>
-                                                <td>@prop.Value</td>
-                                            </tr>
-                                        }
-                                    </tbody>
-                                </table>
-                            }
+							@if (message.ApplicationProperties?.Any() == true) {
+								<strong>Application Properties:</strong>
+								<table class="table table-sm mt-0 mb-2">
+									<tbody>
+										@foreach (var prop in message.ApplicationProperties) {
+											<tr>
+												<td class="w-25">@prop.Key</td>
+												<td>@prop.Value</td>
+											</tr>
+										}
+									</tbody>
+								</table>
+							}
 
-                            <strong>Body:</strong>
-                            <pre class="mt-0 bg-light p-2 rounded">@message.Body</pre>
-                        </div>
-                    </li>
-                }
-            </ul>
-        }
-    </div>
+							<strong>Body:</strong>
+							<pre class="mt-0 bg-light p-2 rounded">@message.Body</pre>
+						</div>
+					</li>
+				}
+			</ul>
+		}
+	</div>
 </div>
 
 @section Scripts {
-    <script>
+	<script>
 				function addProperty() {
-                    const container = document.getElementById('properties-container');
-                    const index = container.querySelectorAll('.input-group').length;
-                    const group = document.createElement('div');
-                    group.className = 'input-group mb-2';
-                    group.innerHTML = `
-        <input type="text" name="SendMessageApplicationProperties[${index}].Key" class="form-control" placeholder="Key" />
+					const container = document.getElementById('properties-container');
+					const index = container.querySelectorAll('.input-group').length;
+					const group = document.createElement('div');
+					group.className = 'input-group mb-2';
+					group.innerHTML = `
+		<input type="text" name="SendMessageApplicationProperties[${index}].Key" class="form-control" placeholder="Key" />
 		<select name="SendMessageApplicationProperties[${index}].Type" class="form-select" style="max-width: 180px;">
 			<option value="String" selected>String</option>
 			<option value="Bool">Bool</option>
@@ -274,135 +274,135 @@
 			<option value="DateTimeOffset">DateTimeOffset</option>
 			<option value="TimeSpan">TimeSpan</option>
 		</select>
-        <input type="text" name="SendMessageApplicationProperties[${index}].Value" class="form-control" placeholder="Value" />
-        <button type="button" class="btn btn-outline-danger">×</button>`;
-                    container.appendChild(group);
-                }
+		<input type="text" name="SendMessageApplicationProperties[${index}].Value" class="form-control" placeholder="Value" />
+		<button type="button" class="btn btn-outline-danger">×</button>`;
+					container.appendChild(group);
+				}
 
-                document.addEventListener('DOMContentLoaded', function () {
-                    function disableButtonOnValidSubmit(formId, submitButtonId) {
-                        const form = document.getElementById(formId);
-                        if (!(form instanceof HTMLFormElement)) {
-                            return;
-                        }
+				document.addEventListener('DOMContentLoaded', function () {
+					function disableButtonOnValidSubmit(formId, submitButtonId) {
+						const form = document.getElementById(formId);
+						if (!(form instanceof HTMLFormElement)) {
+							return;
+						}
 
-                        form.addEventListener('submit', function () {
-                            // If browser validation blocks submit, this handler won't run.
-                            // Use checkValidity in case custom constraints are added later.
-                            if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
-                                return;
-                            }
+						form.addEventListener('submit', function () {
+							// If browser validation blocks submit, this handler won't run.
+							// Use checkValidity in case custom constraints are added later.
+							if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+								return;
+							}
 
-                            const btn = document.getElementById(submitButtonId);
-                            if (btn instanceof HTMLButtonElement) {
-                                btn.disabled = true;
-                            }
-                        });
-                    }
+							const btn = document.getElementById(submitButtonId);
+							if (btn instanceof HTMLButtonElement) {
+								btn.disabled = true;
+							}
+						});
+					}
 
-                    // Disable action buttons after a valid submit to prevent double-posting.
-                    disableButtonOnValidSubmit('sendMessageForm', 'sendMessageSubmitBtn');
-                    disableButtonOnValidSubmit('refreshForm', 'refreshSubmitBtn');
-                    disableButtonOnValidSubmit('receiveForm', 'receiveSubmitBtn');
-                    disableButtonOnValidSubmit('disconnectForm', 'disconnectSubmitBtn');
+					// Disable action buttons after a valid submit to prevent double-posting.
+					disableButtonOnValidSubmit('sendMessageForm', 'sendMessageSubmitBtn');
+					disableButtonOnValidSubmit('refreshForm', 'refreshSubmitBtn');
+					disableButtonOnValidSubmit('receiveForm', 'receiveSubmitBtn');
+					disableButtonOnValidSubmit('disconnectForm', 'disconnectSubmitBtn');
 
-                    function renumberApplicationProperties() {
-                        const container = document.getElementById('properties-container');
-                        if (!container) {
-                            return;
-                        }
+					function renumberApplicationProperties() {
+						const container = document.getElementById('properties-container');
+						if (!container) {
+							return;
+						}
 
-                        const groups = Array.from(container.querySelectorAll('.input-group'));
-                        for (let i = 0; i < groups.length; i++) {
-                            const group = groups[i];
-                            const keyInput = group.querySelector('input[name$=".Key"]');
-                            const valueInput = group.querySelector('input[name$=".Value"]');
+						const groups = Array.from(container.querySelectorAll('.input-group'));
+						for (let i = 0; i < groups.length; i++) {
+							const group = groups[i];
+							const keyInput = group.querySelector('input[name$=".Key"]');
+							const valueInput = group.querySelector('input[name$=".Value"]');
 
-                            if (keyInput) {
-                                keyInput.name = `SendMessageApplicationProperties[${i}].Key`;
-                            }
+							if (keyInput) {
+								keyInput.name = `SendMessageApplicationProperties[${i}].Key`;
+							}
 
-                            if (valueInput) {
-                                valueInput.name = `SendMessageApplicationProperties[${i}].Value`;
-                            }
-                        }
-                    }
+							if (valueInput) {
+								valueInput.name = `SendMessageApplicationProperties[${i}].Value`;
+							}
+						}
+					}
 
-                    const sendFormWrapper = document.getElementById('sendFormWrapper');
-                    const toggleBtn = document.getElementById('toggleSendFormBtn');
+					const sendFormWrapper = document.getElementById('sendFormWrapper');
+					const toggleBtn = document.getElementById('toggleSendFormBtn');
 
-                    if (sendFormWrapper != null && toggleBtn != null) {
-                        const storageKey = 'sendFormOpen';
-                        let isOpen = localStorage.getItem(storageKey);
-                        if (isOpen === null) {
-                            isOpen = 'true';
-                            localStorage.setItem(storageKey, isOpen);
-                        }
-                        isOpen = isOpen === 'true';
+					if (sendFormWrapper != null && toggleBtn != null) {
+						const storageKey = 'sendFormOpen';
+						let isOpen = localStorage.getItem(storageKey);
+						if (isOpen === null) {
+							isOpen = 'true';
+							localStorage.setItem(storageKey, isOpen);
+						}
+						isOpen = isOpen === 'true';
 
-                        function updateFormVisibility() {
-                            if (isOpen) {
-                                sendFormWrapper.classList.remove('js-send-form-hidden');
-                                toggleBtn.textContent = 'Hide Send Message';
-                            } else {
-                                sendFormWrapper.classList.add('js-send-form-hidden');
-                                toggleBtn.textContent = 'Show Send Message';
-                            }
-                        }
+						function updateFormVisibility() {
+							if (isOpen) {
+								sendFormWrapper.classList.remove('js-send-form-hidden');
+								toggleBtn.textContent = 'Hide Send Message';
+							} else {
+								sendFormWrapper.classList.add('js-send-form-hidden');
+								toggleBtn.textContent = 'Show Send Message';
+							}
+						}
 
-                        updateFormVisibility();
+						updateFormVisibility();
 
-                        toggleBtn.addEventListener('click', function () {
-                            sendFormWrapper.classList.add('animation-effect');
-                            isOpen = !isOpen;
-                            localStorage.setItem(storageKey, isOpen);
-                            updateFormVisibility();
-                        });
-                    }
+						toggleBtn.addEventListener('click', function () {
+							sendFormWrapper.classList.add('animation-effect');
+							isOpen = !isOpen;
+							localStorage.setItem(storageKey, isOpen);
+							updateFormVisibility();
+						});
+					}
 
-                    // Message expand/collapse functionality
-                    document.querySelectorAll('.js-toggle-message').forEach(button => {
-                        button.addEventListener('click', function () {
-                            const messageId = this.getAttribute('data-message-id');
-                            const detailsDiv = document.querySelector(`.js-message-details[data-message-id="${messageId}"]`);
-                            const expandText = this.querySelector('.js-expand-text');
-                            const collapseText = this.querySelector('.js-collapse-text');
+					// Message expand/collapse functionality
+					document.querySelectorAll('.js-toggle-message').forEach(button => {
+						button.addEventListener('click', function () {
+							const messageId = this.getAttribute('data-message-id');
+							const detailsDiv = document.querySelector(`.js-message-details[data-message-id="${messageId}"]`);
+							const expandText = this.querySelector('.js-expand-text');
+							const collapseText = this.querySelector('.js-collapse-text');
 
-                            if (detailsDiv.style.display === 'none') {
-                                detailsDiv.style.display = 'block';
-                                expandText.style.display = 'none';
-                                collapseText.style.display = 'inline';
-                            } else {
-                                detailsDiv.style.display = 'none';
-                                expandText.style.display = 'inline';
-                                collapseText.style.display = 'none';
-                            }
-                        });
-                    });
+							if (detailsDiv.style.display === 'none') {
+								detailsDiv.style.display = 'block';
+								expandText.style.display = 'none';
+								collapseText.style.display = 'inline';
+							} else {
+								detailsDiv.style.display = 'none';
+								expandText.style.display = 'inline';
+								collapseText.style.display = 'none';
+							}
+						});
+					});
 
-                    // Ensure indexes stay contiguous for ASP.NET Core model binding.
-                    const propertiesContainer = document.getElementById('properties-container');
-                    if (propertiesContainer) {
-                        propertiesContainer.addEventListener('click', function (e) {
-                            const target = e.target;
-                            if (!(target instanceof HTMLElement)) {
-                                return;
-                            }
+					// Ensure indexes stay contiguous for ASP.NET Core model binding.
+					const propertiesContainer = document.getElementById('properties-container');
+					if (propertiesContainer) {
+						propertiesContainer.addEventListener('click', function (e) {
+							const target = e.target;
+							if (!(target instanceof HTMLElement)) {
+								return;
+							}
 
-                            if (!target.matches('button')) {
-                                return;
-                            }
+							if (!target.matches('button')) {
+								return;
+							}
 
-                            const group = target.closest('.input-group');
-                            if (!group || !propertiesContainer.contains(group)) {
-                                return;
-                            }
+							const group = target.closest('.input-group');
+							if (!group || !propertiesContainer.contains(group)) {
+								return;
+							}
 
-                            group.remove();
-                            renumberApplicationProperties();
-                        });
-                    }
-                });
-    </script>
+							group.remove();
+							renumberApplicationProperties();
+						});
+					}
+				});
+	</script>
 }
 

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -103,10 +103,15 @@
                 <div class="mb-3">
                     <label class="form-label"><strong>Application properties</strong></label>
                     <div id="properties-container">
-                        @for (int i = 0; i < Model.SendMessageApplicationProperties.Count; i++) {
+						@for (int i = 0; i < Model.SendMessageApplicationProperties.Count; i++) {
                             <div class="input-group mb-2">
                                 <input type="text" name="SendMessageApplicationProperties[@i].Key" value="@Model.SendMessageApplicationProperties[i].Key" placeholder="Key" />
-                                <input type="text" name="SendMessageApplicationProperties[@i].Value" value="@Model.SendMessageApplicationProperties[i].Value" class="form-control" placeholder="Value" />
+								<select name="SendMessageApplicationProperties[@i].Type" class="form-select" style="max-width: 180px;">
+									@foreach (var type in Enum.GetValues<ServiceBusViewer.Infrastructure.ServiceBus.Models.ApplicationPropertyType>()) {
+										<option value="@type" selected="@(type == Model.SendMessageApplicationProperties[i].Type)">@type</option>
+									}
+								</select>
+								<input type="text" name="SendMessageApplicationProperties[@i].Value" value="@Model.SendMessageApplicationProperties[i].Value" class="form-control" placeholder="Value" />
                                 <button type="button" class="btn btn-outline-danger">×</button>
                             </div>
                         }
@@ -242,13 +247,33 @@
 
 @section Scripts {
     <script>
-                function addProperty() {
+				function addProperty() {
                     const container = document.getElementById('properties-container');
                     const index = container.querySelectorAll('.input-group').length;
                     const group = document.createElement('div');
                     group.className = 'input-group mb-2';
                     group.innerHTML = `
         <input type="text" name="SendMessageApplicationProperties[${index}].Key" class="form-control" placeholder="Key" />
+		<select name="SendMessageApplicationProperties[${index}].Type" class="form-select" style="max-width: 180px;">
+			<option value="String" selected>String</option>
+			<option value="Bool">Bool</option>
+			<option value="Byte">Byte</option>
+			<option value="SByte">SByte</option>
+			<option value="Short">Short</option>
+			<option value="UShort">UShort</option>
+			<option value="Int">Int</option>
+			<option value="UInt">UInt</option>
+			<option value="Long">Long</option>
+			<option value="ULong">ULong</option>
+			<option value="Float">Float</option>
+			<option value="Double">Double</option>
+			<option value="Decimal">Decimal</option>
+			<option value="Char">Char</option>
+			<option value="Guid">Guid</option>
+			<option value="DateTime">DateTime</option>
+			<option value="DateTimeOffset">DateTimeOffset</option>
+			<option value="TimeSpan">TimeSpan</option>
+		</select>
         <input type="text" name="SendMessageApplicationProperties[${index}].Value" class="form-control" placeholder="Value" />
         <button type="button" class="btn btn-outline-danger">×</button>`;
                     container.appendChild(group);

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -50,12 +50,10 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnGet()
 	{
-		if (!_serviceBusService.Connected) {
+		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
-		}
 
 		try {
-			AvailableEntities = _serviceBusService.AvailableEntities;
 			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
@@ -76,9 +74,8 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostSelectEntity()
 	{
-		if (!_serviceBusService.Connected) {
+		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
-		}
 
 		if (string.IsNullOrWhiteSpace(SelectedEntityName)) {
 			ModelState.AddModelError(string.Empty, "Entity name is required.");
@@ -93,9 +90,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 			};
 
 			_serviceBusService.SwitchActiveEntity(entityInfo);
-			AvailableEntities = _serviceBusService.AvailableEntities;
 
-			// Load messages for the selected entity
 			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
@@ -110,17 +105,13 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostRefresh()
 	{
-		if (!_serviceBusService.Connected) {
+		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
-		}
 
 		try {
 			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
-
-			// Maintain entity list
-			AvailableEntities = _serviceBusService.AvailableEntities;
 		}
 		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Refresh failed: {ex.Message}");
@@ -132,19 +123,15 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostReceive()
 	{
-		if (!_serviceBusService.Connected) {
+		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
-		}
 
 		try {
 			DisplayedMessage = await _serviceBusService.ReceiveMessageAsync();
 
-			var result = await _serviceBusService.PeekMessagesAsync();
+			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
-
-			// Maintain entity list
-			AvailableEntities = _serviceBusService.AvailableEntities;
 		}
 		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Receive failed: {ex.Message}");
@@ -156,30 +143,28 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public async Task<IActionResult> OnPostSend()
 	{
-		if (!_serviceBusService.Connected) {
+		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
-		}
 
 		if (string.IsNullOrWhiteSpace(SendMessageBody)) {
 			ModelState.AddModelError(string.Empty, "Message body cannot be empty.");
 
-			var result = await _serviceBusService.PeekMessagesAsync();
+			AvailableEntities = _serviceBusService.AvailableEntities;
+
+			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
-
-			AvailableEntities = _serviceBusService.AvailableEntities;
 
 			return Page();
 		}
 
 		try {
 			if (!ValidateSystemProperties()) {
-				var invalidResult = await _serviceBusService.PeekMessagesAsync();
+				ReceivedMessageList invalidResult = await _serviceBusService.PeekMessagesAsync();
 				Messages = invalidResult.Messages;
 				HasMoreMessages = invalidResult.HasMore;
 
-				AvailableEntities = _serviceBusService.AvailableEntities;
-
+				FillPageModel();
 				return Page();
 			}
 
@@ -190,12 +175,9 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 			SendMessageApplicationProperties.Clear();
 			SendMessageProperties = new MessageProperties();
 
-			var result = await _serviceBusService.PeekMessagesAsync();
+			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
 			HasMoreMessages = result.HasMore;
-
-			// Maintain entity list
-			AvailableEntities = _serviceBusService.AvailableEntities;
 		}
 		catch (Exception ex) {
 			ModelState.AddModelError(string.Empty, $"Send failed: {ex.Message}");
@@ -210,6 +192,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 		ServiceBusHostName = _serviceBusService.Host;
 		EntityName = _serviceBusService.EntityName;
 		SubscriptionName = _serviceBusService.SubscriptionName;
+		AvailableEntities = _serviceBusService.AvailableEntities;
 	}
 
 	private bool ValidateSystemProperties()

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -5,15 +5,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using ServiceBusViewer.Infrastructure.ServiceBus;
 using ServiceBusViewer.Infrastructure.ServiceBus.Models;
 
-public enum MessageDisplayType
-{
-	None = 0,
-	Peeked,
-	Received
-}
-
-public record ApplicationProperty(string Key, string Value);
-
 public class IndexModel(ServiceBusService serviceBusService) : PageModel
 {
 	private readonly ServiceBusService _serviceBusService = serviceBusService;
@@ -35,7 +26,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	public MessageProperties SendMessageProperties { get; set; } = new();
 
 	[BindProperty]
-	public IList<ApplicationProperty> SendMessageApplicationProperties { get; set; } = new List<ApplicationProperty>();
+	public List<ApplicationProperty> SendMessageApplicationProperties { get; set; } = new List<ApplicationProperty>();
 
 	public string? EntityName { get; set; }
 
@@ -52,8 +43,6 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	public IReadOnlyList<ReceivedMessage> Messages { get; set; } = [];
 
 	public bool HasMoreMessages { get; set; }
-
-	public MessageDisplayType DisplayType { get; set; } = MessageDisplayType.None;
 
 	public ReceivedMessage? DisplayedMessage { get; set; }
 
@@ -149,7 +138,6 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 		try {
 			DisplayedMessage = await _serviceBusService.ReceiveMessageAsync();
-			DisplayType = MessageDisplayType.Received;
 
 			var result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
@@ -195,9 +183,8 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 				return Page();
 			}
 
-			Dictionary<string, object> properties = SendMessageApplicationProperties.ToDictionary(x => x.Key, x => (object)x.Value);
 
-			await _serviceBusService.SendMessageAsync(SendMessageBody, SendMessageProperties, properties);
+			await _serviceBusService.SendMessageAsync(SendMessageBody, SendMessageProperties, SendMessageApplicationProperties);
 			SendResultMessage = "Message sent successfully!";
 			SendMessageBody = string.Empty;
 			SendMessageApplicationProperties.Clear();


### PR DESCRIPTION
This pull request adds support for specifying and handling typed application properties when sending Service Bus messages. Now, users can select the type of each application property (such as `String`, `Int`, `Bool`, etc.) from the UI, and the backend will parse and send these properties with the correct type. This improves the flexibility and correctness of message property handling.