### PR TITLE
Refactor/cache entity list

### DIFF
--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityId.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityId.cs
@@ -2,17 +2,17 @@ namespace ServiceBusViewer.Infrastructure.ServiceBus.Models;
 
 /// <summary>Represents information about a Service Bus entity.</summary>
 /// <param name="Name">The name of the entity.</param>
-public abstract record EntityInfo(string Name);
+public abstract record EntityId(string Name);
 
 /// <summary>Represents information about a Service Bus queue.</summary>
 /// <param name="Name">The name of the queue.</param>
-public record QueueEntityInfo(string Name) : EntityInfo(Name);
+public record QueueEntityId(string Name) : EntityId(Name);
 
 /// <summary>Represents information about a Service Bus topic.</summary>
 /// <param name="Name">The name of the topic.</param>
-public record TopicEntityInfo(string Name) : EntityInfo(Name);
+public record TopicEntityId(string Name) : EntityId(Name);
 
 /// <summary>Represents information about a Service Bus topic subscription.</summary>
 /// <param name="Name">The name of the subscription.</param>
 /// <param name="TopicName">The name of the parent topic.</param>
-public record SubscriptionEntityInfo(string Name, string TopicName) : EntityInfo(Name);
+public record SubscriptionEntityId(string Name, string TopicName) : EntityId(Name);

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
@@ -12,7 +12,7 @@ public class ServiceBusService
 
 	private ServiceBusClient? _client;
 	private ServiceBusAdministrationClient? _adminClient;
-	private readonly List<EntityInfo> _availableEntities = new List<EntityInfo>();
+	private readonly List<EntityProperties> _availableEntities = new List<EntityProperties>();
 
 	/// <summary>Gets a value indicating whether the service is connected to a Service Bus instance.</summary>
 	public bool Connected { get; private set; }
@@ -23,116 +23,112 @@ public class ServiceBusService
 	/// <summary>Gets the entity name (queue or topic) currently connected to.</summary>
 	public string EntityName { get; private set; } = string.Empty;
 
-	/// <summary>Gets the subscription name if connected to a topic subscription; otherwise, null.</summary>
-	public string? SubscriptionName { get; private set; }
+	/// <summary>Gets the parent topic if connected to a topic subscription; otherwise, null.</summary>
+	public string? TopicName { get; private set; }
 
 	/// <summary>Gets a value indicating whether connected using a root connection string with admin privileges.</summary>
 	public bool IsManagementApiAvailable => _adminClient is not null;
 
-	/// <summary>Gets the list of available entities when connected in root mode.</summary>
-	public IReadOnlyList<EntityInfo> AvailableEntities => _availableEntities;
+	/// <summary>Gets the list of available entity properties with full details.</summary>
+	public IReadOnlyList<EntityProperties> AvailableEntities => _availableEntities;
 
 	/// <summary>Connects to the specified Service Bus entity.</summary>
 	/// <param name="connectionString">The Service Bus connection string.</param>
-	/// <param name="entityName">The queue or topic name.</param>
-	/// <param name="subscriptionName">The subscription name, or null for queues.</param>
 	/// <param name="rootConnectionString">Optional root connection string for admin operations.</param>
 	/// <exception cref="InvalidOperationException">Thrown if already connected.</exception>
-	public async Task ConnectToAsync(string connectionString, string? rootConnectionString, string? entityName, string? subscriptionName)
+	public async Task ConnectToAsync(string connectionString, string rootConnectionString)
 	{
 		if (Connected)
 			throw new InvalidOperationException("Already connected to a Service Bus instance.");
 
 		_client = new ServiceBusClient(connectionString);
-
-		if (!string.IsNullOrWhiteSpace(rootConnectionString))
-			_adminClient = new ServiceBusAdministrationClient(rootConnectionString);
+		_adminClient = new ServiceBusAdministrationClient(rootConnectionString);
 
 		Host = GetServiceBusHost(connectionString);
-		EntityName = entityName ?? string.Empty;
-		SubscriptionName = subscriptionName;
+		EntityName = string.Empty;
+		TopicName = null;
 		Connected = true;
-
-		// Populate available entities list
-		if (!IsManagementApiAvailable) {
-			if (string.IsNullOrWhiteSpace(entityName))
-				throw new InvalidOperationException("The topic or subscription name required.");
-
-			if (!string.IsNullOrWhiteSpace(subscriptionName)) {
-				_availableEntities.Add(new TopicEntityInfo(entityName));
-				_availableEntities.Add(new SubscriptionEntityInfo(subscriptionName, entityName));
-			}
-			else {
-				_availableEntities.Add(new QueueEntityInfo(entityName));
-			}
-		}
 
 		await UpdateAvailableEntitiesListAsync();
 	}
 
-	/// <summary>Returns properties for the specified entity using the administration client.</summary>
-	/// <param name="entity">Entity to load properties for.</param>
-	/// <returns>Entity properties with a type matching the requested entity.</returns>
-	/// <exception cref="InvalidOperationException">Thrown if admin client is not configured.</exception>
-	public async Task<EntityProperties> GetEntityPropertiesAsync(EntityInfo entity)
+	/// <summary>Connects to the specified Service Bus entity without using ServiceBusAdministrationClient to get the list of entities.</summary>
+	/// <param name="connectionString">The Service Bus connection string.</param>
+	/// <param name="queueOrTopicName">The queue or topic name.</param>
+	/// <param name="subscriptionName">The subscription name, or <c>null</c> for queues.</param>
+	/// <exception cref="InvalidOperationException">Thrown if already connected.</exception>
+	public async Task ConnectToAsync(string connectionString, string queueOrTopicName, string? subscriptionName)
 	{
-		if (_adminClient is null)
-			throw new InvalidOperationException("Entity properties are available only when connected with a root connection string.");
+		if (Connected)
+			throw new InvalidOperationException("Already connected to a Service Bus instance.");
 
-		return entity switch {
-			QueueEntityInfo queue => await GetQueuePropertiesAsync(queue.Name, _adminClient),
-			TopicEntityInfo topic => await GetTopicPropertiesAsync(topic.Name, _adminClient),
-			SubscriptionEntityInfo subscription => await GetSubscriptionPropertiesAsync(subscription.TopicName, subscription.Name, _adminClient),
-			_ => throw new ArgumentException($"Unknown entity type: {entity.GetType().FullName}")
+		_client = new ServiceBusClient(connectionString);
+		_adminClient = null;
+
+		Host = GetServiceBusHost(connectionString);
+		EntityName = subscriptionName ?? queueOrTopicName;
+		TopicName = subscriptionName is not null ? queueOrTopicName : null;
+		Connected = true;
+
+		// Non-admin mode: create minimal property objects for the connected entity
+		if (string.IsNullOrWhiteSpace(queueOrTopicName))
+			throw new InvalidOperationException("The topic or subscription name required.");
+
+		if (!string.IsNullOrWhiteSpace(subscriptionName)) {
+			// For subscriptions, create both topic and subscription property placeholders
+			_availableEntities.Add(new TopicEntityProperties(
+				queueOrTopicName,
+				TimeSpan.MaxValue,
+				false,
+				TimeSpan.FromMinutes(10),
+				true,
+				false,
+				TimeSpan.MaxValue));
+			_availableEntities.Add(new SubscriptionEntityProperties(
+				subscriptionName,
+				queueOrTopicName,
+				TimeSpan.FromMinutes(1),
+				10,
+				TimeSpan.MaxValue,
+				false,
+				false,
+				true,
+				TimeSpan.MaxValue));
+		}
+		else {
+			// For queues, create a queue property placeholder
+			_availableEntities.Add(new QueueEntityProperties(
+				queueOrTopicName,
+				TimeSpan.FromMinutes(1),
+				10,
+				TimeSpan.MaxValue,
+				false,
+				TimeSpan.FromMinutes(10),
+				false,
+				true,
+				false,
+				false,
+				TimeSpan.MaxValue));
+		}
+	}
+
+	/// <summary>Returns properties for the specified entity from the cache.</summary>
+	/// <param name="entityId">Entity to load properties for.</param>
+	/// <returns>Entity properties with a type matching the requested entity.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if entity is not found in cache.</exception>
+	public EntityProperties GetEntityPropertiesAsync(EntityId entityId)
+	{
+		EntityProperties? properties = entityId switch {
+			QueueEntityId queueId => _availableEntities.FirstOrDefault(p => p is QueueEntityProperties && p.Name == queueId.Name),
+			TopicEntityId topicId => _availableEntities.FirstOrDefault(p => p is TopicEntityProperties && p.Name == topicId.Name),
+			SubscriptionEntityId subscriptionId => _availableEntities.FirstOrDefault(p => p is SubscriptionEntityProperties sp && sp.Name == subscriptionId.Name && sp.TopicName == subscriptionId.TopicName),
+			_ => throw new ArgumentException($"Unknown entity type: {entityId.GetType().FullName}")
 		};
 
-		static async Task<QueueEntityProperties> GetQueuePropertiesAsync(string queueName, ServiceBusAdministrationClient adminClient)
-		{
-			QueueProperties properties = await adminClient.GetQueueAsync(queueName);
+		if (properties is null)
+			throw new InvalidOperationException($"Entity properties for '{entityId.Name}' not found in cache. Please refresh the entity list.");
 
-			return new QueueEntityProperties(
-				properties.Name,
-				properties.LockDuration,
-				properties.MaxDeliveryCount,
-				properties.DefaultMessageTimeToLive,
-				properties.RequiresDuplicateDetection,
-				properties.DuplicateDetectionHistoryTimeWindow,
-				properties.DeadLetteringOnMessageExpiration,
-				properties.EnableBatchedOperations,
-				properties.RequiresSession,
-				properties.EnablePartitioning,
-				properties.AutoDeleteOnIdle);
-		}
-
-		static async Task<TopicEntityProperties> GetTopicPropertiesAsync(string topicName, ServiceBusAdministrationClient adminClient)
-		{
-			TopicProperties properties = await adminClient.GetTopicAsync(topicName);
-
-			return new TopicEntityProperties(
-				properties.Name,
-				properties.DefaultMessageTimeToLive,
-				properties.RequiresDuplicateDetection,
-				properties.DuplicateDetectionHistoryTimeWindow,
-				properties.EnableBatchedOperations,
-				properties.EnablePartitioning,
-				properties.AutoDeleteOnIdle);
-		}
-
-		static async Task<SubscriptionEntityProperties> GetSubscriptionPropertiesAsync(string topicName, string subscriptionName, ServiceBusAdministrationClient adminClient)
-		{
-			SubscriptionProperties properties = await adminClient.GetSubscriptionAsync(topicName, subscriptionName);
-
-			return new SubscriptionEntityProperties(
-				properties.SubscriptionName,
-				properties.TopicName,
-				properties.LockDuration,
-				properties.MaxDeliveryCount,
-				properties.DefaultMessageTimeToLive,
-				properties.DeadLetteringOnMessageExpiration,
-				properties.RequiresSession,
-				properties.EnableBatchedOperations,
-				properties.AutoDeleteOnIdle);
-		}
+		return properties;
 	}
 
 	/// <summary>Disconnects asynchronously from the current Service Bus instance.</summary>
@@ -151,7 +147,7 @@ public class ServiceBusService
 
 		Host = string.Empty;
 		EntityName = string.Empty;
-		SubscriptionName = null;
+		TopicName = null;
 		Connected = false;
 	}
 
@@ -230,29 +226,85 @@ public class ServiceBusService
 		await sender.SendMessageAsync(message);
 	}
 
-	internal static object ConvertApplicationPropertyValue(string value, ApplicationPropertyType type)
+	/// <summary>Retrieves all available entities (queues, topics, and subscriptions) with their properties from the Service Bus namespace.</summary>
+	/// <returns>A task representing the asynchronous operation.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if admin client is not available.</exception>
+	public async Task UpdateAvailableEntitiesListAsync()
 	{
-		return type switch {
-			ApplicationPropertyType.String => value,
-			ApplicationPropertyType.Bool => bool.Parse(value),
-			ApplicationPropertyType.Byte => byte.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.SByte => sbyte.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Short => short.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.UShort => ushort.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Int => int.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.UInt => uint.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Long => long.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.ULong => ulong.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Float => float.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Double => double.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Decimal => decimal.Parse(value, CultureInfo.InvariantCulture),
-			ApplicationPropertyType.Char => value.Length == 1 ? value[0] : throw new FormatException("Char value must be a single character."),
-			ApplicationPropertyType.Guid => Guid.Parse(value),
-			ApplicationPropertyType.DateTime => DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
-			ApplicationPropertyType.DateTimeOffset => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
-			ApplicationPropertyType.TimeSpan => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
-			_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported application property type.")
-		};
+		if (_adminClient is null)
+			throw new InvalidOperationException("Entity list refresh is only available when connected with a root connection string.");
+
+		_availableEntities.Clear();
+
+		// Get all queues with properties
+		await foreach (QueueProperties queue in _adminClient.GetQueuesAsync()) {
+			_availableEntities.Add(new QueueEntityProperties(
+				queue.Name,
+				queue.LockDuration,
+				queue.MaxDeliveryCount,
+				queue.DefaultMessageTimeToLive,
+				queue.RequiresDuplicateDetection,
+				queue.DuplicateDetectionHistoryTimeWindow,
+				queue.DeadLetteringOnMessageExpiration,
+				queue.EnableBatchedOperations,
+				queue.RequiresSession,
+				queue.EnablePartitioning,
+				queue.AutoDeleteOnIdle));
+		}
+
+		// Get all topics and their subscriptions with properties
+		await foreach (TopicProperties topic in _adminClient.GetTopicsAsync()) {
+			_availableEntities.Add(new TopicEntityProperties(
+				topic.Name,
+				topic.DefaultMessageTimeToLive,
+				topic.RequiresDuplicateDetection,
+				topic.DuplicateDetectionHistoryTimeWindow,
+				topic.EnableBatchedOperations,
+				topic.EnablePartitioning,
+				topic.AutoDeleteOnIdle));
+
+			await foreach (SubscriptionProperties subscription in _adminClient.GetSubscriptionsAsync(topic.Name)) {
+				_availableEntities.Add(new SubscriptionEntityProperties(
+					subscription.SubscriptionName,
+					subscription.TopicName,
+					subscription.LockDuration,
+					subscription.MaxDeliveryCount,
+					subscription.DefaultMessageTimeToLive,
+					subscription.DeadLetteringOnMessageExpiration,
+					subscription.RequiresSession,
+					subscription.EnableBatchedOperations,
+					subscription.AutoDeleteOnIdle));
+			}
+		}
+	}
+
+
+	/// <summary>Switches the active entity without disconnecting from the Service Bus.</summary>
+	/// <param name="entity">The entity to switch to.</param>
+	/// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
+	public void SwitchActiveEntity(EntityId entity)
+	{
+		if (!Connected || _client is null)
+			throw new InvalidOperationException("Not connected to any Service Bus instance.");
+
+		// No need to create a new client, just update the entity information
+		switch (entity) {
+			case QueueEntityId queueId:
+				EntityName = queueId.Name;
+				TopicName = null;
+				break;
+
+			case SubscriptionEntityId subscriptionId:
+				EntityName = subscriptionId.Name;
+				TopicName = subscriptionId.TopicName;
+				break;
+
+			case TopicEntityId topicId:
+				throw new InvalidOperationException($"Please select the subscription for the topic {topicId.Name}");
+
+			default:
+				throw new ArgumentException($"Unknown entity type: {entity.GetType().FullName}");
+		}
 	}
 
 	/// <summary>Gets a <see cref="ServiceBusReceiver"/> for the current entity and subscription.</summary>
@@ -263,8 +315,8 @@ public class ServiceBusService
 		if (!Connected || _client is null)
 			throw new InvalidOperationException("Service Bus is not connected.");
 
-		if (!string.IsNullOrWhiteSpace(SubscriptionName)) {
-			return _client.CreateReceiver(EntityName, SubscriptionName, new ServiceBusReceiverOptions {
+		if (!string.IsNullOrWhiteSpace(TopicName)) {
+			return _client.CreateReceiver(TopicName, EntityName, new ServiceBusReceiverOptions {
 				ReceiveMode = ServiceBusReceiveMode.PeekLock
 			});
 		}
@@ -303,57 +355,6 @@ public class ServiceBusService
 		return host.ToString();
 	}
 
-	/// <summary>Retrieves all available entities (queues, topics, and subscriptions) from the Service Bus namespace.</summary>
-	/// <returns>A list of <see cref="EntityInfo"/> representing all entities.</returns>
-	/// <exception cref="InvalidOperationException">Thrown if not connected in root mode.</exception>
-	public async Task UpdateAvailableEntitiesListAsync()
-	{
-		if (_adminClient is null) // Keep pre-configured entity list if admin client was not configured
-			return;
-
-		_availableEntities.Clear();
-
-		// Get all queues
-		await foreach (QueueProperties? queue in _adminClient.GetQueuesAsync())
-			_availableEntities.Add(new QueueEntityInfo(queue.Name));
-
-		// Get all topics and their subscriptions
-		await foreach (TopicProperties? topic in _adminClient.GetTopicsAsync()) {
-			_availableEntities.Add(new TopicEntityInfo(topic.Name));
-
-			await foreach (SubscriptionProperties? subscription in _adminClient.GetSubscriptionsAsync(topic.Name))
-				_availableEntities.Add(new SubscriptionEntityInfo(subscription.SubscriptionName, topic.Name));
-		}
-	}
-
-	/// <summary>Switches the active entity without disconnecting from the Service Bus.</summary>
-	/// <param name="entity">The entity to switch to.</param>
-	/// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
-	public void SwitchActiveEntity(EntityInfo entity)
-	{
-		if (!Connected || _client is null)
-			throw new InvalidOperationException("Not connected to any Service Bus instance.");
-
-		// No need to create a new client, just update the entity information
-		switch (entity) {
-			case QueueEntityInfo queue:
-				EntityName = queue.Name;
-				SubscriptionName = null;
-				break;
-
-			case SubscriptionEntityInfo subscription:
-				EntityName = subscription.TopicName;
-				SubscriptionName = subscription.Name;
-				break;
-
-			case TopicEntityInfo topic:
-				throw new InvalidOperationException($"Please select the subscription for the topic {topic.Name}");
-
-			default:
-				throw new ArgumentException($"Unknown entity type: {entity.GetType().FullName}");
-		}
-	}
-
 	private static ReceivedMessage ConvertToMessageDetails(ServiceBusReceivedMessage message)
 	{
 		var properties = new ReceivedMessageProperties(
@@ -370,5 +371,30 @@ public class ServiceBusService
 			message.Body.ToString(),
 			properties,
 			message.ApplicationProperties);
+	}
+
+	private static object ConvertApplicationPropertyValue(string value, ApplicationPropertyType type)
+	{
+		return type switch {
+			ApplicationPropertyType.String => value,
+			ApplicationPropertyType.Bool => bool.Parse(value),
+			ApplicationPropertyType.Byte => byte.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.SByte => sbyte.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Short => short.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.UShort => ushort.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Int => int.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.UInt => uint.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Long => long.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.ULong => ulong.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Float => float.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Double => double.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Decimal => decimal.Parse(value, CultureInfo.InvariantCulture),
+			ApplicationPropertyType.Char => value.Length == 1 ? value[0] : throw new FormatException("Char value must be a single character."),
+			ApplicationPropertyType.Guid => Guid.Parse(value),
+			ApplicationPropertyType.DateTime => DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+			ApplicationPropertyType.DateTimeOffset => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
+			ApplicationPropertyType.TimeSpan => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
+			_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported application property type.")
+		};
 	}
 }

--- a/src/ServiceBusViewer/Pages/Connect.cshtml
+++ b/src/ServiceBusViewer/Pages/Connect.cshtml
@@ -27,7 +27,7 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Queue or Topic Name</label>
-        <input type="text" name="EntityName" value="@Model.EntityName" class="form-control" />
+        <input type="text" name="QueueOrTopicName" value="@Model.QueueOrTopicName" class="form-control" />
         <small class="form-text text-muted">
             Required when not using root connection string.
         </small>

--- a/src/ServiceBusViewer/Pages/Connect.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Connect.cshtml.cs
@@ -16,7 +16,7 @@ public class ConnectModel(ServiceBusService serviceBusService) : PageModel
 	public string? RootConnectionString { get; set; } = Environment.GetEnvironmentVariable("ROOT_CONNECTION_STRING");
 
 	[BindProperty(SupportsGet = true)]
-	public string? EntityName { get; set; }
+	public string? QueueOrTopicName { get; set; }
 
 	[BindProperty(SupportsGet = true)]
 	public string? SubscriptionName { get; set; }
@@ -37,13 +37,17 @@ public class ConnectModel(ServiceBusService serviceBusService) : PageModel
 			return Page();
 		}
 
-		if (string.IsNullOrWhiteSpace(RootConnectionString) && string.IsNullOrWhiteSpace(EntityName)) {
+		if (string.IsNullOrWhiteSpace(RootConnectionString) && string.IsNullOrWhiteSpace(QueueOrTopicName)) {
 			ModelState.AddModelError(string.Empty, "Queue/Topic name is required when not using root connection.");
 			return Page();
 		}
 
 		try {
-			await _serviceBusService.ConnectToAsync(ConnectionString, RootConnectionString, EntityName, SubscriptionName);
+			if (!string.IsNullOrWhiteSpace(RootConnectionString))
+				await _serviceBusService.ConnectToAsync(ConnectionString, RootConnectionString);
+			else
+				await _serviceBusService.ConnectToAsync(ConnectionString, QueueOrTopicName!, SubscriptionName);
+
 			return RedirectToPage("/Index");
 		}
 		catch (Exception ex) {

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml
@@ -14,7 +14,7 @@
 }
 
 <div class="row" style="height: calc(100vh - 200px);">
-    @await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.Name, Model.TopicName, Model.IsManagementApiAvailable))
+    @await Html.PartialAsync("_EntityList", new EntityListModel(Model.AvailableEntities, Model.Name, Model.TopicName, Model.IsManagementApiAvailable))
 
     <div class="col-md-9" style="overflow-y: auto; height: 100%;">
         <h3>Entity properties</h3>

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml
@@ -14,7 +14,7 @@
 }
 
 <div class="row" style="height: calc(100vh - 200px);">
-    @await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityNameForSelection, Model.SubscriptionNameForSelection, Model.IsManagementApiAvailable))
+    @await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.Name, Model.TopicName, Model.IsManagementApiAvailable))
 
     <div class="col-md-9" style="overflow-y: auto; height: 100%;">
         <h3>Entity properties</h3>

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml.cs
@@ -18,15 +18,6 @@ public class EntityInfoModel(ServiceBusService serviceBusService) : PageModel
 	[BindProperty(SupportsGet = true)]
 	public string? TopicName { get; set; }
 
-	[BindProperty]
-	public string? SelectedEntityName { get; set; }
-
-	[BindProperty]
-	public string? SelectedEntityType { get; set; }
-
-	[BindProperty]
-	public string? SelectedTopicName { get; set; }
-
 	public string ServiceBusHostName { get; set; } = string.Empty;
 
 	public bool IsManagementApiAvailable => _serviceBusService.IsManagementApiAvailable;
@@ -35,19 +26,15 @@ public class EntityInfoModel(ServiceBusService serviceBusService) : PageModel
 
 	public string? ErrorMessage { get; private set; }
 
-	public IReadOnlyList<EntityInfo> AvailableEntities { get; private set; } = Array.Empty<EntityInfo>();
-
-	public string? EntityNameForSelection { get; private set; }
-
-	public string? SubscriptionNameForSelection { get; private set; }
+	public IReadOnlyList<EntityId> AvailableEntities { get; private set; } = [];
 
 	public async Task<IActionResult> OnGet()
 	{
 		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
 
-		AvailableEntities = _serviceBusService.AvailableEntities;
-		SetSelectedEntityContext();
+		AvailableEntities = ConvertToEntityIdList(_serviceBusService.AvailableEntities);
+		ServiceBusHostName = _serviceBusService.Host;
 
 		if (string.IsNullOrWhiteSpace(Type) || string.IsNullOrWhiteSpace(Name)) {
 			ErrorMessage = "Entity type and name are required.";
@@ -55,95 +42,29 @@ public class EntityInfoModel(ServiceBusService serviceBusService) : PageModel
 		}
 
 		try {
-			EntityInfo entity = Type.ToLowerInvariant() switch {
-				"queue" => new QueueEntityInfo(Name!),
-				"topic" => new TopicEntityInfo(Name!),
-				"subscription" when !string.IsNullOrWhiteSpace(TopicName) => new SubscriptionEntityInfo(Name!, TopicName!),
+			EntityId entity = Type.ToLowerInvariant() switch {
+				"queue" => new QueueEntityId(Name!),
+				"topic" => new TopicEntityId(Name!),
+				"subscription" when !string.IsNullOrWhiteSpace(TopicName) => new SubscriptionEntityId(Name!, TopicName!),
 				_ => throw new InvalidOperationException("Unsupported entity type or missing topic name for subscription.")
 			};
 
-			Properties = await _serviceBusService.GetEntityPropertiesAsync(entity);
+			Properties = _serviceBusService.GetEntityPropertiesAsync(entity);
 		}
 		catch (Exception ex) {
 			ErrorMessage = ex.Message;
 		}
 
-		FillPageModel();
-
 		return Page();
 	}
 
-	public IActionResult OnPostSelectEntity()
+	private static IReadOnlyList<EntityId> ConvertToEntityIdList(IReadOnlyList<EntityProperties> properties)
 	{
-		if (!_serviceBusService.Connected)
-			return RedirectToPage("/Connect");
-
-		AvailableEntities = _serviceBusService.AvailableEntities;
-
-		if (string.IsNullOrWhiteSpace(SelectedEntityName)) {
-			ModelState.AddModelError(string.Empty, "Entity name is required.");
-			Type = SelectedEntityType;
-			Name = SelectedEntityName;
-			TopicName = SelectedTopicName;
-			SetSelectedEntityContext();
-			return Page();
-		}
-
-		if (string.Equals(SelectedEntityType, "Subscription", StringComparison.OrdinalIgnoreCase)
-			&& string.IsNullOrWhiteSpace(SelectedTopicName)) {
-			ModelState.AddModelError(string.Empty, "Topic name is required for subscription selection.");
-			Type = SelectedEntityType;
-			Name = SelectedEntityName;
-			TopicName = SelectedTopicName;
-			SetSelectedEntityContext();
-			return Page();
-		}
-
-		try {
-			EntityInfo entityInfo = SelectedEntityType switch {
-				"Subscription" => new SubscriptionEntityInfo(SelectedEntityName!, SelectedTopicName!),
-				"Topic" => new TopicEntityInfo(SelectedEntityName!),
-				_ => new QueueEntityInfo(SelectedEntityName!)
-			};
-
-			_serviceBusService.SwitchActiveEntity(entityInfo);
-
-			string targetType = SelectedEntityType ?? "Queue";
-			string? targetTopicName = SelectedEntityType == "Subscription" ? SelectedTopicName : null;
-
-			return RedirectToPage(new { type = targetType, name = SelectedEntityName, topicName = targetTopicName });
-		}
-		catch (Exception ex) {
-			ModelState.AddModelError(string.Empty, ex.Message);
-		}
-
-		Type = SelectedEntityType;
-		Name = SelectedEntityName;
-		TopicName = SelectedTopicName;
-
-		SetSelectedEntityContext();
-		FillPageModel();
-
-		return Page();
-	}
-
-	private void SetSelectedEntityContext()
-	{
-		switch (Type?.ToLowerInvariant()) {
-			case "subscription" when !string.IsNullOrWhiteSpace(TopicName):
-				EntityNameForSelection = TopicName;
-				SubscriptionNameForSelection = Name;
-				break;
-
-			default:
-				EntityNameForSelection = Name;
-				SubscriptionNameForSelection = null;
-				break;
-		}
-	}
-
-	private void FillPageModel()
-	{
-		ServiceBusHostName = _serviceBusService.Host;
+		return properties.Select(p => (EntityId)(p switch {
+			QueueEntityProperties queue => new QueueEntityId(queue.Name),
+			TopicEntityProperties topic => new TopicEntityId(topic.Name),
+			SubscriptionEntityProperties subscription => new SubscriptionEntityId(subscription.Name, subscription.TopicName),
+			_ => throw new ArgumentException($"Unknown entity properties type: {p.GetType().FullName}")
+		})).ToList();
 	}
 }

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -37,7 +37,7 @@
 
 <div class="row" style="height: calc(100vh - 200px);">
 	<!-- Left Panel: Entity List -->
-	@await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityName, Model.SubscriptionName, Model.IsManagementApiAvailable))
+	@await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityName, Model.TopicName, Model.IsManagementApiAvailable))
 
 	<!-- Right Panel: Messages and Operations -->
 	<div class="col-md-9" style="overflow-y: auto; height: 100%;">

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -37,7 +37,7 @@
 
 <div class="row" style="height: calc(100vh - 200px);">
 	<!-- Left Panel: Entity List -->
-	@await Html.PartialAsync("_EntityList", new EntityListViewModel(Model.AvailableEntities, Model.EntityName, Model.TopicName, Model.IsManagementApiAvailable))
+	@await Html.PartialAsync("_EntityList", new EntityListModel(Model.AvailableEntities, Model.EntityName, Model.TopicName, Model.IsManagementApiAvailable))
 
 	<!-- Right Panel: Messages and Operations -->
 	<div class="col-md-9" style="overflow-y: auto; height: 100%;">

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -11,15 +11,6 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	private const int MaxSystemPropertyLength = 128;
 
 	[BindProperty]
-	public string? SelectedEntityName { get; set; }
-
-	[BindProperty]
-	public string? SelectedEntityType { get; set; }
-
-	[BindProperty]
-	public string? SelectedTopicName { get; set; }
-
-	[BindProperty]
 	public string? SendMessageBody { get; set; }
 
 	[BindProperty]
@@ -30,15 +21,13 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 	public string? EntityName { get; set; }
 
-	public string? SubscriptionName { get; set; }
-
-	public bool IsConnected => _serviceBusService.Connected;
+	public string? TopicName { get; set; }
 
 	public bool IsManagementApiAvailable => _serviceBusService.IsManagementApiAvailable;
 
 	public string ServiceBusHostName { get; set; } = string.Empty;
 
-	public IReadOnlyList<EntityInfo> AvailableEntities { get; set; } = [];
+	public IReadOnlyList<EntityId> AvailableEntities { get; set; } = [];
 
 	public IReadOnlyList<ReceivedMessage> Messages { get; set; } = [];
 
@@ -72,21 +61,21 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 		return RedirectToPage("/Connect");
 	}
 
-	public async Task<IActionResult> OnPostSelectEntity()
+	public async Task<IActionResult> OnPostSelectEntity(string selectedEntityType, string selectedEntityName, string? selectedTopicName)
 	{
 		if (!_serviceBusService.Connected)
 			return RedirectToPage("/Connect");
 
-		if (string.IsNullOrWhiteSpace(SelectedEntityName)) {
+		if (string.IsNullOrWhiteSpace(selectedEntityName)) {
 			ModelState.AddModelError(string.Empty, "Entity name is required.");
 			return Page();
 		}
 
 		try {
-			EntityInfo entityInfo = SelectedEntityType switch {
-				"Subscription" => new SubscriptionEntityInfo(SelectedEntityName!, SelectedTopicName!),
-				"Topic" => new TopicEntityInfo(SelectedEntityName!),
-				_ => new QueueEntityInfo(SelectedEntityName!)
+			EntityId entityInfo = selectedEntityType switch {
+				"Subscription" => new SubscriptionEntityId(selectedEntityName, selectedTopicName!),
+				"Topic" => new TopicEntityId(selectedEntityName),
+				_ => new QueueEntityId(selectedEntityName)
 			};
 
 			_serviceBusService.SwitchActiveEntity(entityInfo);
@@ -149,7 +138,7 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 		if (string.IsNullOrWhiteSpace(SendMessageBody)) {
 			ModelState.AddModelError(string.Empty, "Message body cannot be empty.");
 
-			AvailableEntities = _serviceBusService.AvailableEntities;
+			AvailableEntities = ConvertToEntityIdList(_serviceBusService.AvailableEntities);
 
 			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
@@ -191,8 +180,8 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	{
 		ServiceBusHostName = _serviceBusService.Host;
 		EntityName = _serviceBusService.EntityName;
-		SubscriptionName = _serviceBusService.SubscriptionName;
-		AvailableEntities = _serviceBusService.AvailableEntities;
+		TopicName = _serviceBusService.TopicName;
+		AvailableEntities = ConvertToEntityIdList(_serviceBusService.AvailableEntities);
 	}
 
 	private bool ValidateSystemProperties()
@@ -211,5 +200,15 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 
 		ModelState.AddModelError($"{nameof(SendMessageProperties)}.{propertyName}", $"The {displayName} must be {MaxSystemPropertyLength} characters or fewer.");
 		return false;
+	}
+
+	private static IReadOnlyList<EntityId> ConvertToEntityIdList(IReadOnlyList<EntityProperties> properties)
+	{
+		return properties.Select(p => (EntityId)(p switch {
+			QueueEntityProperties queue => new QueueEntityId(queue.Name),
+			TopicEntityProperties topic => new TopicEntityId(topic.Name),
+			SubscriptionEntityProperties subscription => new SubscriptionEntityId(subscription.Name, subscription.TopicName),
+			_ => throw new ArgumentException($"Unknown entity properties type: {p.GetType().FullName}")
+		})).ToList();
 	}
 }

--- a/src/ServiceBusViewer/Pages/Shared/EntityListViewModel.cs
+++ b/src/ServiceBusViewer/Pages/Shared/EntityListViewModel.cs
@@ -3,7 +3,7 @@ namespace ServiceBusViewer.Pages.Shared;
 using ServiceBusViewer.Infrastructure.ServiceBus.Models;
 
 public sealed record EntityListViewModel(
-	IReadOnlyList<EntityInfo> AvailableEntities,
+	IReadOnlyList<EntityId> AvailableEntities,
 	string? EntityName,
-	string? SubscriptionName,
-	bool ManagementApiEnabled);
+	string? TopicName, // The parent Topic name for Subscription
+	bool DisplayPropertyLinks);

--- a/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml
+++ b/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml
@@ -1,4 +1,4 @@
-@model ServiceBusViewer.Pages.Shared.EntityListViewModel
+@model ServiceBusViewer.Pages.Shared.EntityListModel
 @using ServiceBusViewer.Infrastructure.ServiceBus.Models
 
 <div class="col-md-3 border-end" style="overflow-y: auto; height: 100%;">

--- a/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml
+++ b/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml
@@ -5,8 +5,8 @@
     <h3>Entities</h3>
     @if (Model.AvailableEntities.Count > 0) {
         <div class="list-group">
-            @foreach (var queue in Model.AvailableEntities.OfType<QueueEntityInfo>()) {
-                <div class="list-group-item d-flex align-items-center @(Model.EntityName == queue.Name && Model.SubscriptionName == null ? "list-group-item-primary" : "")">
+            @foreach (var queue in Model.AvailableEntities.OfType<QueueEntityId>()) {
+                <div class="list-group-item d-flex align-items-center @(Model.EntityName == queue.Name && Model.TopicName == null ? "list-group-item-primary" : "")">
                     <form method="post" asp-page="/Index" asp-page-handler="SelectEntity" class="flex-grow-1 mb-0">
                         @Html.AntiForgeryToken()
                         <input type="hidden" name="SelectedEntityName" value="@queue.Name" />
@@ -15,7 +15,7 @@
                             <img src="~/components/entity-list/queue.svg" alt="Queue" class="icon" /> @queue.Name
                         </button>
                     </form>
-                    @if (Model.ManagementApiEnabled) {
+                    @if (Model.DisplayPropertyLinks) {
                         <a class="btn btn-sm" asp-page="/EntityInfo" asp-route-type="Queue" asp-route-name="@queue.Name" title="View queue properties">
                             <img src="~/components/entity-list/info.svg" alt="View queue properties" />
                         </a>
@@ -23,18 +23,18 @@
                 </div>
             }
 
-            @foreach (var topic in Model.AvailableEntities.OfType<TopicEntityInfo>()) {
+            @foreach (var topic in Model.AvailableEntities.OfType<TopicEntityId>()) {
                 <div>
                     <div class="list-group-item bg-light d-flex align-items-center justify-content-between">
                         <span><img src="~/components/entity-list/topic.svg" alt="Topic" class="icon" /> @topic.Name</span>
-                        @if (Model.ManagementApiEnabled) {
+                        @if (Model.DisplayPropertyLinks) {
                             <a class="btn btn-sm" asp-page="/EntityInfo" asp-route-type="Topic" asp-route-name="@topic.Name" title="View topic properties">
                                 <img src="~/components/entity-list/info.svg" alt="View topic properties" />
                             </a>
                         }
                     </div>
-                    @foreach (var subscription in Model.AvailableEntities.OfType<SubscriptionEntityInfo>().Where(e => e.TopicName == topic.Name)) {
-                        <div class="list-group-item d-flex align-items-center ps-4 @(Model.EntityName == topic.Name && Model.SubscriptionName == subscription.Name ? "list-group-item-primary" : "")">
+                    @foreach (var subscription in Model.AvailableEntities.OfType<SubscriptionEntityId>().Where(e => e.TopicName == topic.Name)) {
+                        <div class="list-group-item d-flex align-items-center ps-4 @(Model.EntityName == subscription.Name && Model.TopicName == topic.Name ? "list-group-item-primary" : "")">
                             <form method="post" asp-page="/Index" asp-page-handler="SelectEntity" class="flex-grow-1 mb-0">
                                 @Html.AntiForgeryToken()
                                 <input type="hidden" name="SelectedEntityName" value="@subscription.Name" />
@@ -44,7 +44,7 @@
                                     <img src="~/components/entity-list/subscription.svg" alt="Subscription" class="icon" /> @subscription.Name
                                 </button>
                             </form>
-                            @if (Model.ManagementApiEnabled) {
+                            @if (Model.DisplayPropertyLinks) {
                                 <a class="btn btn-sm" asp-page="/EntityInfo" asp-route-type="Subscription" asp-route-name="@subscription.Name" asp-route-topicname="@subscription.TopicName" title="View subscription properties">
                                     <img src="~/components/entity-list/info.svg" alt="View subscription properties" />
                                 </a>

--- a/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Shared/_EntityList.cshtml.cs
@@ -2,7 +2,7 @@ namespace ServiceBusViewer.Pages.Shared;
 
 using ServiceBusViewer.Infrastructure.ServiceBus.Models;
 
-public sealed record EntityListViewModel(
+public sealed record EntityListModel(
 	IReadOnlyList<EntityId> AvailableEntities,
 	string? EntityName,
 	string? TopicName, // The parent Topic name for Subscription


### PR DESCRIPTION
This pull request refactors Service Bus entity handling to provide richer entity information and simplify connection logic. The main changes include renaming and restructuring entity types, updating connection methods to distinguish between admin/root and non-root modes, and improving entity property retrieval and switching. UI and model properties have also been updated for clarity and consistency.

### Entity Model Refactoring

* Renamed and refactored entity identifier types: `EntityInfo` and its derived types have been replaced with `EntityId`, `QueueEntityId`, `TopicEntityId`, and `SubscriptionEntityId` to clarify their purpose as identifiers. (`src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityId.cs`)
* Entity properties are now handled using `EntityProperties` and its derived types, enabling richer property information for queues, topics, and subscriptions. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)

### Service Bus Connection and Entity Management

* Connection logic is split into two methods: one for root/admin connections (retrieves all entities/properties) and one for direct entity connections (creates minimal property placeholders). (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)
* Entity property retrieval now uses cached properties and entity identifiers, removing admin client dependency for non-root connections. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)
* Entity switching and entity list updating are improved, with admin/root mode supporting full entity refresh and switching based on identifier types. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`) [[1]](diffhunk://#diff-a6b8dc0c6eb717279261d722eef2adfef70bfaca55a035838d79af71a70843faL233-R307) [[2]](diffhunk://#diff-a6b8dc0c6eb717279261d722eef2adfef70bfaca55a035838d79af71a70843faL306-L356)

### UI and Model Consistency

* Updated UI and model property names from `EntityName` to `QueueOrTopicName` for clarity in connect page and model. (`src/ServiceBusViewer/Pages/Connect.cshtml`, `src/ServiceBusViewer/Pages/Connect.cshtml.cs`) [[1]](diffhunk://#diff-5ee30cf70a9b6f3d6bbf22a9658f86dd157670f934c114efad9affed8ad08df0L30-R30) [[2]](diffhunk://#diff-fa00d8073158dd60ba96b5b46ce3280559fade748aac1b304a7d6922ac9be03eL19-R19)
* Connection logic in the page model now uses the new connection method signatures and property names. (`src/ServiceBusViewer/Pages/Connect.cshtml.cs`)

### Miscellaneous Improvements

* Moved and refactored application property value conversion utility for better code organization. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)
* Updated receiver creation logic to use new topic/subscription naming conventions. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)
* Updated disconnect logic to match new property names. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)