### PR TITLE
Reading sessions

### DIFF
--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
@@ -188,6 +188,23 @@ public class ServiceBusService
 		return ConvertToMessageDetails(message);
 	}
 
+	/// <summary>Receives and completes a single message from a session-enabled Service Bus entity.</summary>
+	/// <param name="sessionId">The session ID to accept. If null or empty, accepts the next available session.</param>
+	/// <returns>The <see cref="ReceivedMessage"/> of the received message, or null if no message is available.</returns>
+	public async Task<ReceivedMessage?> ReceiveSessionMessageAsync(string? sessionId)
+	{
+		await using ServiceBusSessionReceiver sessionReceiver = await GetSessionReceiver(sessionId);
+
+		ServiceBusReceivedMessage? message = await sessionReceiver.ReceiveMessageAsync();
+
+		if (message is null)
+			return null;
+
+		await sessionReceiver.CompleteMessageAsync(message);
+
+		return ConvertToMessageDetails(message);
+	}
+
 	/// <summary>Sends a message to the connected Service Bus entity.</summary>
 	/// <param name="content">The message content.</param>
 	/// <param name="messageProperties">The optional system properties to include with the message.</param>
@@ -324,6 +341,26 @@ public class ServiceBusService
 		return _client.CreateReceiver(EntityName, new ServiceBusReceiverOptions {
 			ReceiveMode = ServiceBusReceiveMode.PeekLock
 		});
+	}
+
+	/// <summary>Gets a <see cref="ServiceBusSessionReceiver"/> for the current entity.</summary>
+	/// <param name="sessionId">The session ID to accept. If null or empty, accepts the next available session.</param>
+	/// <returns>A <see cref="ServiceBusSessionReceiver"/> instance.</returns>
+	/// <exception cref="InvalidOperationException">Thrown if not connected.</exception>
+	private async Task<ServiceBusSessionReceiver> GetSessionReceiver(string? sessionId)
+	{
+		if (!Connected || _client is null)
+			throw new InvalidOperationException("Service Bus is not connected.");
+
+		if (!string.IsNullOrWhiteSpace(TopicName)) {
+			return string.IsNullOrEmpty(sessionId)
+				? await _client.AcceptNextSessionAsync(TopicName, EntityName)
+				: await _client.AcceptSessionAsync(TopicName, EntityName, sessionId);
+		}
+
+		return string.IsNullOrEmpty(sessionId)
+			? await _client.AcceptNextSessionAsync(EntityName)
+			: await _client.AcceptSessionAsync(EntityName, sessionId);
 	}
 
 	/// <summary>Gets a <see cref="ServiceBusSender"/> for the current entity.</summary>

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -41,16 +41,19 @@
 
 	<!-- Right Panel: Messages and Operations -->
 	<div class="col-md-9" style="overflow-y: auto; height: 100%;">
-		<div class="d-flex gap-2 mb-3">
+	<div class="d-flex flex-wrap align-items-center gap-2 pt-2 mb-3">
 			<form method="post" asp-page-handler="Refresh" class="mb-0" id="refreshForm">
 				@Html.AntiForgeryToken()
 				<button type="submit" class="btn btn-outline-success" id="refreshSubmitBtn">Refresh</button>
 			</form>
 
-			<form method="post" asp-page-handler="Receive" class="mb-0" id="receiveForm">
-				@Html.AntiForgeryToken()
+		<form method="post" asp-page-handler="Receive" class="mb-0" id="receiveForm">
+			@Html.AntiForgeryToken()
+			<div class="input-group">
+				<input type="text" id="receiveSessionIdInput" name="ReceiveSessionId" value="@Model.ReceiveSessionId" placeholder="Session ID" class="form-control" style="max-width: 200px;" disabled="@(Model.RequiresSession ? null : "disabled")" />
 				<button type="submit" class="btn btn-outline-primary" id="receiveSubmitBtn">Receive</button>
-			</form>
+			</div>
+		</form>
 
 			<button type="button" id="toggleSendFormBtn" class="btn btn-outline-secondary">Show Send Message</button>
 
@@ -186,7 +189,11 @@
 					<li class="list-group-item">
 						<div class="d-flex justify-content-between align-items-center">
 							<div>
-								<strong>@message.Properties.MessageId</strong> - <em>@message.Properties.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
+								<strong>@message.Properties.MessageId</strong> -
+								@if (!string.IsNullOrWhiteSpace(message.Properties.SessionId)) {
+									<em> Session ID: @message.Properties.SessionId - </em>
+								}
+								<em> @message.Properties.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
 							</div>
 							<button type="button" class="btn btn-sm btn-outline-primary js-toggle-message" data-message-id="@message.Properties.MessageId">
 								<span class="js-expand-text">▼ Expand</span>
@@ -280,7 +287,7 @@
 				}
 
 				document.addEventListener('DOMContentLoaded', function () {
-					function disableButtonOnValidSubmit(formId, submitButtonId) {
+				function disableButtonOnValidSubmit(formId, submitButtonId, relatedInputIds) {
 						const form = document.getElementById(formId);
 						if (!(form instanceof HTMLFormElement)) {
 							return;
@@ -293,17 +300,28 @@
 								return;
 							}
 
-							const btn = document.getElementById(submitButtonId);
-							if (btn instanceof HTMLButtonElement) {
-								btn.disabled = true;
-							}
+						const btn = document.getElementById(submitButtonId);
+						if (btn instanceof HTMLButtonElement) {
+							btn.disabled = true;
+						}
+
+						if (Array.isArray(relatedInputIds)) {
+							relatedInputIds.forEach(id => {
+								const input = document.getElementById(id);
+								if (input instanceof HTMLInputElement) {
+									input.readOnly = true;
+									input.setAttribute('aria-disabled', 'true');
+									input.classList.add('disabled');
+								}
+							});
+						}
 						});
 					}
 
 					// Disable action buttons after a valid submit to prevent double-posting.
 					disableButtonOnValidSubmit('sendMessageForm', 'sendMessageSubmitBtn');
 					disableButtonOnValidSubmit('refreshForm', 'refreshSubmitBtn');
-					disableButtonOnValidSubmit('receiveForm', 'receiveSubmitBtn');
+					disableButtonOnValidSubmit('receiveForm', 'receiveSubmitBtn', ['receiveSessionIdInput']);
 					disableButtonOnValidSubmit('disconnectForm', 'disconnectSubmitBtn');
 
 					function renumberApplicationProperties() {
@@ -405,4 +423,3 @@
 				});
 	</script>
 }
-

--- a/src/ServiceBusViewer/Pages/Index.cshtml
+++ b/src/ServiceBusViewer/Pages/Index.cshtml
@@ -50,7 +50,7 @@
 		<form method="post" asp-page-handler="Receive" class="mb-0" id="receiveForm">
 			@Html.AntiForgeryToken()
 			<div class="input-group">
-				<input type="text" id="receiveSessionIdInput" name="ReceiveSessionId" value="@Model.ReceiveSessionId" placeholder="Session ID" class="form-control" style="max-width: 200px;" disabled="@(Model.RequiresSession ? null : "disabled")" />
+				<input type="text" id="receiveSessionIdInput" name="ReceiveSessionId" value="@Model.ReceiveSessionId" placeholder="Session ID" class="form-control" style="max-width: 200px;" @(!Model.RequiresSession ? "disabled='disabled'" : null) />
 				<button type="submit" class="btn btn-outline-primary" id="receiveSubmitBtn">Receive</button>
 			</div>
 		</form>
@@ -189,10 +189,10 @@
 					<li class="list-group-item">
 						<div class="d-flex justify-content-between align-items-center">
 							<div>
-								<strong>@message.Properties.MessageId</strong> -
-								@if (!string.IsNullOrWhiteSpace(message.Properties.SessionId)) {
-									<em> Session ID: @message.Properties.SessionId - </em>
-								}
+							<strong>@message.Properties.MessageId</strong> -
+							@if (Model.RequiresSession && !string.IsNullOrWhiteSpace(message.Properties.SessionId)) {
+								<em> Session ID: @message.Properties.SessionId - </em>
+							}
 								<em> @message.Properties.EnqueuedTimeUtc.ToLocalTime().ToString("g")</em>
 							</div>
 							<button type="button" class="btn btn-sm btn-outline-primary js-toggle-message" data-message-id="@message.Properties.MessageId">

--- a/src/ServiceBusViewer/Pages/Index.cshtml.cs
+++ b/src/ServiceBusViewer/Pages/Index.cshtml.cs
@@ -19,9 +19,14 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 	[BindProperty]
 	public List<ApplicationProperty> SendMessageApplicationProperties { get; set; } = new List<ApplicationProperty>();
 
+	[BindProperty]
+	public string? ReceiveSessionId { get; set; }
+
 	public string? EntityName { get; set; }
 
 	public string? TopicName { get; set; }
+
+	public bool RequiresSession { get; set; }
 
 	public bool IsManagementApiAvailable => _serviceBusService.IsManagementApiAvailable;
 
@@ -116,7 +121,10 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 			return RedirectToPage("/Connect");
 
 		try {
-			DisplayedMessage = await _serviceBusService.ReceiveMessageAsync();
+			bool requiresSession = GetRequiresSession();
+			DisplayedMessage = requiresSession
+				? await _serviceBusService.ReceiveSessionMessageAsync(ReceiveSessionId)
+				: await _serviceBusService.ReceiveMessageAsync();
 
 			ReceivedMessageList result = await _serviceBusService.PeekMessagesAsync();
 			Messages = result.Messages;
@@ -182,6 +190,29 @@ public class IndexModel(ServiceBusService serviceBusService) : PageModel
 		EntityName = _serviceBusService.EntityName;
 		TopicName = _serviceBusService.TopicName;
 		AvailableEntities = ConvertToEntityIdList(_serviceBusService.AvailableEntities);
+		RequiresSession = GetRequiresSession();
+		if (!RequiresSession)
+			ReceiveSessionId = string.Empty;
+	}
+
+	private bool GetRequiresSession()
+	{
+		if (string.IsNullOrWhiteSpace(_serviceBusService.EntityName))
+			return false;
+
+		if (!string.IsNullOrWhiteSpace(_serviceBusService.TopicName)) {
+			SubscriptionEntityProperties? subscription = _serviceBusService.AvailableEntities
+				.OfType<SubscriptionEntityProperties>()
+				.FirstOrDefault(s => s.Name == _serviceBusService.EntityName && s.TopicName == _serviceBusService.TopicName);
+
+			return subscription?.RequiresSession ?? false;
+		}
+
+		QueueEntityProperties? queue = _serviceBusService.AvailableEntities
+			.OfType<QueueEntityProperties>()
+			.FirstOrDefault(q => q.Name == _serviceBusService.EntityName);
+
+		return queue?.RequiresSession ?? false;
 	}
 
 	private bool ValidateSystemProperties()


### PR DESCRIPTION
This pull request adds support for receiving messages from session-enabled Azure Service Bus entities, allowing users to specify a session ID when receiving messages. It also improves the UI to make session information visible and disables form inputs to prevent double submissions. The most important changes are grouped below by backend and frontend enhancements.

**Backend: Session Message Support**

* Added `ReceiveSessionMessageAsync` method to `ServiceBusService` for receiving and completing a message from a session-enabled entity, optionally using a specified session ID.
* Implemented `GetSessionReceiver` to obtain a session receiver for the current entity, supporting both topic/subscription and queue scenarios.
* Updated `IndexModel.OnPostReceive` to use session-aware receiving logic, calling `ReceiveSessionMessageAsync` when sessions are required.
* Added `ReceiveSessionId` and `RequiresSession` properties to `IndexModel`, and logic to determine if the current entity requires sessions. [[1]](diffhunk://#diff-e48071879fe3491c06ded0232d0fdd6d6c3cc92456d04a80f3bec7a3fbb37cb5R22-R30) [[2]](diffhunk://#diff-e48071879fe3491c06ded0232d0fdd6d6c3cc92456d04a80f3bec7a3fbb37cb5R193-R215)

**Frontend: UI Enhancements for Session Support**

* Modified `Index.cshtml` to add a session ID input to the receive form, display session ID in the message list, and disable inputs/buttons after submit to prevent double-posting. [[1]](diffhunk://#diff-83702b66fb92ff8f972e36d62bdcca14f8b01e41795c25ce600bd76e1a7e1340L44-R55) [[2]](diffhunk://#diff-83702b66fb92ff8f972e36d62bdcca14f8b01e41795c25ce600bd76e1a7e1340L189-R196) [[3]](diffhunk://#diff-83702b66fb92ff8f972e36d62bdcca14f8b01e41795c25ce600bd76e1a7e1340L283-R290) [[4]](diffhunk://#diff-83702b66fb92ff8f972e36d62bdcca14f8b01e41795c25ce600bd76e1a7e1340R307-R324) [[5]](diffhunk://#diff-83702b66fb92ff8f972e36d62bdcca14f8b01e41795c25ce600bd76e1a7e1340L408)