### PR TITLE
Display subscription filters

### DIFF
--- a/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
+++ b/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
@@ -120,7 +120,7 @@
                     "properties": {
                       "filterType": "Sql",
                       "sqlFilter": {
-                        "sqlExpression": "group > 2"
+                        "sqlExpression": "1 = 1"
                       },
                       "action": {}
                     }
@@ -212,7 +212,7 @@
                     "properties": {
                       "filterType": "Sql",
                       "sqlFilter": {
-                        "sqlExpression": "group > 2"
+                        "sqlExpression": "1 = 1"
                       },
                       "action": {}
                     }

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs
@@ -66,18 +66,7 @@ public sealed record SubscriptionEntityProperties(
 	bool RequiresSession,
 	bool EnableBatchedOperations,
 	TimeSpan AutoDeleteOnIdle,
-	IReadOnlyList<SubscriptionRule> Rules) : EntityProperties(Name);
-
-/// <summary>Represents a subscription rule (filter and action).</summary>
-/// <param name="Name">Rule name.</param>
-/// <param name="FilterType">Type of filter.</param>
-/// <param name="FilterExpression">Filter expression or details.</param>
-/// <param name="ActionExpression">Action expression if present.</param>
-public sealed record SubscriptionRule(
-	string Name,
-	RuleFilterType FilterType,
-	string FilterExpression,
-	string? ActionExpression);
+	IReadOnlyList<SubscriptionFilterRule> Rules) : EntityProperties(Name);
 
 /// <summary>Represents the type of filter applied to a Service Bus subscription rule.</summary>
 public enum RuleFilterType

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs
@@ -55,6 +55,7 @@ public sealed record TopicEntityProperties(
 /// <param name="RequiresSession">Indicates whether sessions are required.</param>
 /// <param name="EnableBatchedOperations">Enable batched operations.</param>
 /// <param name="AutoDeleteOnIdle">The <see cref="TimeSpan"/> idle interval after which the queue is automatically deleted.</param>
+/// <param name="Rules">Subscription rules (filters and actions).</param>
 public sealed record SubscriptionEntityProperties(
 	string Name,
 	string TopicName,
@@ -64,4 +65,35 @@ public sealed record SubscriptionEntityProperties(
 	bool DeadLetteringOnMessageExpiration,
 	bool RequiresSession,
 	bool EnableBatchedOperations,
-	TimeSpan AutoDeleteOnIdle) : EntityProperties(Name);
+	TimeSpan AutoDeleteOnIdle,
+	IReadOnlyList<SubscriptionRule> Rules) : EntityProperties(Name);
+
+/// <summary>Represents a subscription rule (filter and action).</summary>
+/// <param name="Name">Rule name.</param>
+/// <param name="FilterType">Type of filter.</param>
+/// <param name="FilterExpression">Filter expression or details.</param>
+/// <param name="ActionExpression">Action expression if present.</param>
+public sealed record SubscriptionRule(
+	string Name,
+	RuleFilterType FilterType,
+	string FilterExpression,
+	string? ActionExpression);
+
+/// <summary>Represents the type of filter applied to a Service Bus subscription rule.</summary>
+public enum RuleFilterType
+{
+	/// <summary>Unknown or unsupported filter type.</summary>
+	Unknown = 0,
+
+	/// <summary>SQL filter that evaluates expressions against message properties.</summary>
+	Sql = 1,
+
+	/// <summary>Correlation filter that matches specific message properties.</summary>
+	Correlation = 2,
+
+	/// <summary>True filter that accepts all messages.</summary>
+	True = 3,
+
+	/// <summary>False filter that rejects all messages.</summary>
+	False = 4
+}

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/SubscriptionFilterRule.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/Models/SubscriptionFilterRule.cs
@@ -1,0 +1,47 @@
+namespace ServiceBusViewer.Infrastructure.ServiceBus.Models;
+
+/// <summary>Base class for Service Bus subscription filter rules.</summary>
+public abstract record SubscriptionFilterRule(string Name);
+
+/// <summary>SQL filter rule that evaluates expressions against message properties.</summary>
+/// <param name="Name">Rule name.</param>
+/// <param name="SqlExpression">SQL filter expression.</param>
+/// <param name="ActionExpression">Optional SQL action expression.</param>
+public sealed record SqlSubscriptionFilterRule(
+	string Name,
+	string SqlExpression,
+	string? ActionExpression) : SubscriptionFilterRule(Name);
+
+/// <summary>Correlation filter rule that matches specific message properties.</summary>
+/// <param name="Name">Rule name.</param>
+/// <param name="CorrelationId">Correlation ID filter.</param>
+/// <param name="MessageId">Message ID filter.</param>
+/// <param name="To">To property filter.</param>
+/// <param name="ReplyTo">Reply-to property filter.</param>
+/// <param name="Subject">Subject property filter.</param>
+/// <param name="SessionId">Session ID filter.</param>
+/// <param name="ReplyToSessionId">Reply-to session ID filter.</param>
+/// <param name="ContentType">Content type filter.</param>
+/// <param name="ApplicationProperties">Custom application properties to filter on.</param>
+/// <param name="ActionExpression">Optional SQL action expression.</param>
+public sealed record CorrelationSubscriptionFilterRule(
+	string Name,
+	string? CorrelationId,
+	string? MessageId,
+	string? To,
+	string? ReplyTo,
+	string? Subject,
+	string? SessionId,
+	string? ReplyToSessionId,
+	string? ContentType,
+	IReadOnlyDictionary<string, object> ApplicationProperties,
+	string? ActionExpression) : SubscriptionFilterRule(Name);
+
+/// <summary>Unknown or unsupported rule type.</summary>
+/// <param name="Name">Rule name.</param>
+/// <param name="FilterTypeName">Name of the unsupported filter type.</param>
+/// <param name="FilterExpression">Filter details or error message.</param>
+public sealed record UnknownSubscriptionFilterRule(
+	string Name,
+	string FilterTypeName,
+	string FilterExpression) : SubscriptionFilterRule(Name);

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
@@ -283,7 +283,7 @@ public class ServiceBusService
 
 			await foreach (SubscriptionProperties subscription in _adminClient.GetSubscriptionsAsync(topic.Name)) {
 				// Get subscription rules (filters)
-				List<SubscriptionRule> rules = [];
+				List<SubscriptionFilterRule> rules = [];
 				await foreach (RuleProperties rule in _adminClient.GetRulesAsync(topic.Name, subscription.SubscriptionName)) {
 					rules.Add(ConvertToSubscriptionRule(rule));
 				}
@@ -454,67 +454,42 @@ public class ServiceBusService
 		}
 	}
 
-	private static SubscriptionRule ConvertToSubscriptionRule(RuleProperties rule)
+	private static SubscriptionFilterRule ConvertToSubscriptionRule(RuleProperties rule)
 	{
-		RuleFilterType filterType;
-		string filterExpression;
+		if (rule.Filter is SqlRuleFilter sqlFilter) {
+			string? actionExpression = rule.Action is SqlRuleAction sqlAction
+				? sqlAction.SqlExpression
+				: null;
 
-		switch (rule.Filter) {
-
-			case CorrelationRuleFilter correlationFilter: {
-				filterType = RuleFilterType.Correlation;
-				var correlationParts = new List<string>();
-
-				if (!string.IsNullOrEmpty(correlationFilter.CorrelationId))
-					correlationParts.Add($"CorrelationId = '{correlationFilter.CorrelationId}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.MessageId))
-					correlationParts.Add($"MessageId = '{correlationFilter.MessageId}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.To))
-					correlationParts.Add($"To = '{correlationFilter.To}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.ReplyTo))
-					correlationParts.Add($"ReplyTo = '{correlationFilter.ReplyTo}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.Subject))
-					correlationParts.Add($"Subject = '{correlationFilter.Subject}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.SessionId))
-					correlationParts.Add($"SessionId = '{correlationFilter.SessionId}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.ReplyToSessionId))
-					correlationParts.Add($"ReplyToSessionId = '{correlationFilter.ReplyToSessionId}'");
-
-				if (!string.IsNullOrEmpty(correlationFilter.ContentType))
-					correlationParts.Add($"ContentType = '{correlationFilter.ContentType}'");
-
-				if (correlationFilter.ApplicationProperties.Count > 0) {
-					foreach (KeyValuePair<string, object> prop in correlationFilter.ApplicationProperties)
-						correlationParts.Add($"{prop.Key} = '{prop.Value}'");
-				}
-
-				filterExpression = correlationParts.Any()
-					? string.Join(", ", correlationParts)
-					: "No properties set";
-				break;
-			}
-
-			case SqlRuleFilter sqlFilter:
-				filterType = RuleFilterType.Sql;
-				filterExpression = sqlFilter.SqlExpression;
-				break;
-
-			default:
-				filterType = RuleFilterType.Unknown;
-				filterExpression = rule.Filter?.GetType().Name ?? "null";
-				break;
+			return new SqlSubscriptionFilterRule(rule.Name, sqlFilter.SqlExpression, actionExpression);
 		}
 
-		string? actionExpression = rule.Action is SqlRuleAction sqlAction
-			? sqlAction.SqlExpression
-			: null;
+		if (rule.Filter is CorrelationRuleFilter correlationFilter) {
+			string? actionExpression = rule.Action is SqlRuleAction sqlAction
+				? sqlAction.SqlExpression
+				: null;
 
-		return new SubscriptionRule(rule.Name, filterType, filterExpression, actionExpression);
+			var applicationProperties = correlationFilter.ApplicationProperties
+				.ToDictionary(x => x.Key, x => x.Value) as IReadOnlyDictionary<string, object>
+				?? new Dictionary<string, object>();
+
+			return new CorrelationSubscriptionFilterRule(
+				rule.Name,
+				correlationFilter.CorrelationId,
+				correlationFilter.MessageId,
+				correlationFilter.To,
+				correlationFilter.ReplyTo,
+				correlationFilter.Subject,
+				correlationFilter.SessionId,
+				correlationFilter.ReplyToSessionId,
+				correlationFilter.ContentType,
+				applicationProperties,
+				actionExpression);
+		}
+
+		return new UnknownSubscriptionFilterRule(
+			rule.Name,
+			rule.Filter?.GetType().Name ?? "null",
+			"Unknown filter type");
 	}
 }

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs
@@ -93,7 +93,8 @@ public class ServiceBusService
 				false,
 				false,
 				true,
-				TimeSpan.MaxValue));
+				TimeSpan.MaxValue,
+				[]));
 		}
 		else {
 			// For queues, create a queue property placeholder
@@ -281,6 +282,12 @@ public class ServiceBusService
 				topic.AutoDeleteOnIdle));
 
 			await foreach (SubscriptionProperties subscription in _adminClient.GetSubscriptionsAsync(topic.Name)) {
+				// Get subscription rules (filters)
+				List<SubscriptionRule> rules = [];
+				await foreach (RuleProperties rule in _adminClient.GetRulesAsync(topic.Name, subscription.SubscriptionName)) {
+					rules.Add(ConvertToSubscriptionRule(rule));
+				}
+
 				_availableEntities.Add(new SubscriptionEntityProperties(
 					subscription.SubscriptionName,
 					subscription.TopicName,
@@ -290,7 +297,8 @@ public class ServiceBusService
 					subscription.DeadLetteringOnMessageExpiration,
 					subscription.RequiresSession,
 					subscription.EnableBatchedOperations,
-					subscription.AutoDeleteOnIdle));
+					subscription.AutoDeleteOnIdle,
+					rules));
 			}
 		}
 	}
@@ -444,5 +452,69 @@ public class ServiceBusService
 		catch (OverflowException ex) {
 			throw new FormatException($"Value '{value}' is out of range for type {type}. {ex.Message}", ex);
 		}
+	}
+
+	private static SubscriptionRule ConvertToSubscriptionRule(RuleProperties rule)
+	{
+		RuleFilterType filterType;
+		string filterExpression;
+
+		switch (rule.Filter) {
+
+			case CorrelationRuleFilter correlationFilter: {
+				filterType = RuleFilterType.Correlation;
+				var correlationParts = new List<string>();
+
+				if (!string.IsNullOrEmpty(correlationFilter.CorrelationId))
+					correlationParts.Add($"CorrelationId = '{correlationFilter.CorrelationId}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.MessageId))
+					correlationParts.Add($"MessageId = '{correlationFilter.MessageId}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.To))
+					correlationParts.Add($"To = '{correlationFilter.To}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.ReplyTo))
+					correlationParts.Add($"ReplyTo = '{correlationFilter.ReplyTo}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.Subject))
+					correlationParts.Add($"Subject = '{correlationFilter.Subject}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.SessionId))
+					correlationParts.Add($"SessionId = '{correlationFilter.SessionId}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.ReplyToSessionId))
+					correlationParts.Add($"ReplyToSessionId = '{correlationFilter.ReplyToSessionId}'");
+
+				if (!string.IsNullOrEmpty(correlationFilter.ContentType))
+					correlationParts.Add($"ContentType = '{correlationFilter.ContentType}'");
+
+				if (correlationFilter.ApplicationProperties.Count > 0) {
+					foreach (KeyValuePair<string, object> prop in correlationFilter.ApplicationProperties)
+						correlationParts.Add($"{prop.Key} = '{prop.Value}'");
+				}
+
+				filterExpression = correlationParts.Any()
+					? string.Join(", ", correlationParts)
+					: "No properties set";
+				break;
+			}
+
+			case SqlRuleFilter sqlFilter:
+				filterType = RuleFilterType.Sql;
+				filterExpression = sqlFilter.SqlExpression;
+				break;
+
+			default:
+				filterType = RuleFilterType.Unknown;
+				filterExpression = rule.Filter?.GetType().Name ?? "null";
+				break;
+		}
+
+		string? actionExpression = rule.Action is SqlRuleAction sqlAction
+			? sqlAction.SqlExpression
+			: null;
+
+		return new SubscriptionRule(rule.Name, filterType, filterExpression, actionExpression);
 	}
 }

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml
@@ -65,6 +65,23 @@
                             <tr><th scope="row">Default TTL</th><td>@subscription.DefaultMessageTimeToLive</td></tr>
                             <tr><th scope="row">Dead-letter on Expiration</th><td>@subscription.DeadLetteringOnMessageExpiration</td></tr>
                             <tr><th scope="row">Auto Delete on Idle</th><td>@subscription.AutoDeleteOnIdle</td></tr>
+                            @if (subscription.Rules.Count > 0) {
+                                <tr class="table-secondary">
+                                    <th scope="row" colspan="2">Subscription Rules (@subscription.Rules.Count)</th>
+                                </tr>
+                                @foreach (var rule in subscription.Rules) {
+                                    <tr>
+                                        <th scope="row">Rule: @rule.Name</th>
+                                        <td>
+                                            <div><strong>Filter Type:</strong> @rule.FilterType</div>
+                                            <div><strong>Filter:</strong> @rule.FilterExpression</div>
+                                            @if (!string.IsNullOrEmpty(rule.ActionExpression)) {
+                                                <div><strong>Action:</strong> @rule.ActionExpression</div>
+                                            }
+                                        </td>
+                                    </tr>
+                                }
+                            }
                             break;
 
                         default:

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml
@@ -73,10 +73,62 @@
                                     <tr>
                                         <th scope="row">Rule: @rule.Name</th>
                                         <td>
-                                            <div><strong>Filter Type:</strong> @rule.FilterType</div>
-                                            <div><strong>Filter:</strong> @rule.FilterExpression</div>
-                                            @if (!string.IsNullOrEmpty(rule.ActionExpression)) {
-                                                <div><strong>Action:</strong> @rule.ActionExpression</div>
+                                            @switch (rule) {
+                                                case SqlSubscriptionFilterRule sqlRule:
+                                                    <div><strong>Type:</strong> SQL Filter</div>
+                                                    <div><strong>Expression:</strong> @sqlRule.SqlExpression</div>
+                                                    @if (!string.IsNullOrEmpty(sqlRule.ActionExpression)) {
+                                                        <div><strong>Action:</strong> @sqlRule.ActionExpression</div>
+                                                    }
+                                                    break;
+
+                                                case CorrelationSubscriptionFilterRule correlationRule:
+                                                    <div><strong>Type:</strong> Correlation Filter</div>
+                                                    @if (!string.IsNullOrEmpty(correlationRule.CorrelationId)) {
+                                                        <div><strong>CorrelationId:</strong> @correlationRule.CorrelationId</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.MessageId)) {
+                                                        <div><strong>MessageId:</strong> @correlationRule.MessageId</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.To)) {
+                                                        <div><strong>To:</strong> @correlationRule.To</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.ReplyTo)) {
+                                                        <div><strong>ReplyTo:</strong> @correlationRule.ReplyTo</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.Subject)) {
+                                                        <div><strong>Subject:</strong> @correlationRule.Subject</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.SessionId)) {
+                                                        <div><strong>SessionId:</strong> @correlationRule.SessionId</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.ReplyToSessionId)) {
+                                                        <div><strong>ReplyToSessionId:</strong> @correlationRule.ReplyToSessionId</div>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.ContentType)) {
+                                                        <div><strong>ContentType:</strong> @correlationRule.ContentType</div>
+                                                    }
+                                                    @if (correlationRule.ApplicationProperties.Count > 0) {
+                                                        <div><strong>Application Properties:</strong></div>
+                                                        <ul class="mt-5">
+                                                            @foreach (var prop in correlationRule.ApplicationProperties) {
+                                                                <li>@prop.Key = @prop.Value</li>
+                                                            }
+                                                        </ul>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(correlationRule.ActionExpression)) {
+                                                        <div><strong>Action:</strong> @correlationRule.ActionExpression</div>
+                                                    }
+                                                    break;
+
+                                                case UnknownSubscriptionFilterRule unknownRule:
+                                                    <div><strong>Type:</strong> @unknownRule.FilterTypeName</div>
+                                                    <div><strong>Details:</strong> @unknownRule.FilterExpression</div>
+                                                    break;
+
+                                                default:
+                                                    <div>Unsupported rule type: @rule.GetType().Name</div>
+                                                    break;
                                             }
                                         </td>
                                     </tr>

--- a/src/ServiceBusViewer/Pages/EntityInfo.cshtml
+++ b/src/ServiceBusViewer/Pages/EntityInfo.cshtml
@@ -127,7 +127,7 @@
                                                     break;
 
                                                 default:
-                                                    <div>Unsupported rule type: @rule.GetType().Name</div>
+                                                    <div>Unsupported rule type.</div>
                                                     break;
                                             }
                                         </td>


### PR DESCRIPTION
This pull request adds full support for displaying Service Bus subscription rules (filters and actions) in the application. The changes introduce new model types for rules, update the data retrieval logic to include rules for each subscription, and enhance the UI to present detailed rule information.

**Subscription Rules Support**

* Added new record types to represent different kinds of subscription filter rules (`SqlSubscriptionFilterRule`, `CorrelationSubscriptionFilterRule`, and `UnknownSubscriptionFilterRule`) and a base `SubscriptionFilterRule` class. Also introduced the `RuleFilterType` enum. (`src/ServiceBusViewer/Infrastructure/ServiceBus/Models/SubscriptionFilterRule.cs`, `src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs`) [[1]](diffhunk://#diff-98cdbcd73ad7132dfda8f75f25098e0bbd37c2f5523263654715a23538880393R1-R47) [[2]](diffhunk://#diff-a22179ed6da0495111ffe6faba68ea3c0721a5290766ffd6678caf26ad0fd350L67-R88)
* Updated the `SubscriptionEntityProperties` record to include a `Rules` property for holding a list of subscription rules. (`src/ServiceBusViewer/Infrastructure/ServiceBus/Models/EntityProperties.cs`)

**Backend Logic Enhancements**

* Modified the service layer to fetch and convert subscription rules for each topic subscription, using a new `ConvertToSubscriptionRule` method. Rules are now populated when listing available entities. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`) [[1]](diffhunk://#diff-a6b8dc0c6eb717279261d722eef2adfef70bfaca55a035838d79af71a70843faR285-R290) [[2]](diffhunk://#diff-a6b8dc0c6eb717279261d722eef2adfef70bfaca55a035838d79af71a70843faL293-R301) [[3]](diffhunk://#diff-a6b8dc0c6eb717279261d722eef2adfef70bfaca55a035838d79af71a70843faR456-R494)
* Updated the queue property placeholder logic to account for the new `Rules` property. (`src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusService.cs`)

**UI Improvements**

* Enhanced the entity details page to display all rules for a subscription, showing detailed information for SQL and Correlation filters, including filter expressions, actions, and application properties. (`src/ServiceBusViewer/Pages/EntityInfo.cshtml`)
