### PR TITLE
Update Docker image tags to use lowercase repo names

### DIFF
--- a/.github/workflows/build-canary-container-image.yml
+++ b/.github/workflows/build-canary-container-image.yml
@@ -32,4 +32,4 @@ jobs:
         context: .
         file: ./src/ServiceBusViewer/Dockerfile
         push: true
-        tags: ghcr.io/veselovandrey/ServiceBusViewer:canary
+        tags: ghcr.io/veselovandrey/servicebusviewer:canary

--- a/.github/workflows/build-release-container-image.yml
+++ b/.github/workflows/build-release-container-image.yml
@@ -56,5 +56,5 @@ jobs:
         file: ./src/ServiceBusViewer/Dockerfile
         push: true
         tags: |
-          ghcr.io/veselovandrey/ServiceBusViewer:latest
-          ghcr.io/veselovandrey/ServiceBusViewer:${{ steps.version.outputs.version }}
+          ghcr.io/veselovandrey/servicebusviewer:latest
+          ghcr.io/veselovandrey/servicebusviewer:${{ steps.version.outputs.version }}


### PR DESCRIPTION
This pull request makes a small but important update to the container image publishing process. The change standardizes the Docker image tags by updating the casing of the repository name from `ServiceBusViewer` (PascalCase) to `servicebusviewer` (lowercase) to follow Docker and GitHub naming conventions.

Most important change:

* Updated the image tags in both `.github/workflows/build-canary-container-image.yml` and `.github/workflows/build-release-container-image.yml` to use the lowercase repository name `servicebusviewer` instead of `ServiceBusViewer`. [[1]](diffhunk://#diff-041234bfcd733044a141b1e45ceac84b1e0a37b98036fb94f920e653927cda8cL35-R35) [[2]](diffhunk://#diff-7773cfc693b77ed5c7cc0cdbdb5a8c2137e9c62e3407cb6ae84b97e3e8273648L59-R60)