### PR TITLE
• fix: long peeked message previews. Prevent expanded message bodies …

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
 
 ## Version history
 
+- 30.0.1 (2026-08-11):
+  - Prevented long expanded message bodies from increasing the width of the Peeked Messages table.
+
 - 0.30.0 (2026-08-09):
   - Replaced the Razor UI with a React + Vite SPA and reorganized the backend as a minimal API.
   - Isolated viewer state and Service Bus connections by browser session.

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -491,7 +491,7 @@ export function ViewerPage() {
                               </tr>
                               {isExpanded ? (
                                 <tr className="bg-slate-50/70 dark:bg-slate-950/50">
-                                  <td colSpan={5} className="px-4 py-4">
+                                  <td colSpan={5} className="max-w-0 px-4 py-4">
                                     <div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
                                       <div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
                                         <table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.30.0</Version>
+		<Version>30.0.1</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
This pull request is a patch release focused on improving the user interface of the Peeked Messages table to prevent long expanded message bodies from affecting the table layout. The version is incremented to 30.0.1 and the change is documented in the project history.

UI Improvements:

* Added a `max-w-0` class to the expanded message row in the Peeked Messages table, preventing long message bodies from increasing the table's width.