### PR TITLE
- feat(web): add persistent entity sidebar filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
 
 ## Version history
 
-- 30.0.1 (2026-08-11):
-  - Prevented long expanded message bodies from increasing the width of the Peeked Messages table.
+- 0.31.0 (2026-08-11):
+  - **Added:** An entity sidebar filter with debounced input, immediate application on Enter, and state preserved between viewer and entity details pages.
+  - **Fixed:** Long expanded message bodies increasing the width of the Peeked Messages table.
 
 - 0.30.0 (2026-08-09):
   - Replaced the Razor UI with a React + Vite SPA and reorganized the backend as a minimal API.
@@ -108,17 +109,23 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
   - Added typed application properties.
   - Added entity list caching.
 
-- 0.8.0 (2026-02-05): Added queue/topic/subscription properties view.
+- 0.8.0 (2026-02-05): 
+  - Added queue/topic/subscription properties view.
 
-- 0.7.0 (2026-02-01): Implemented client-side message expansion/collapse for better UX.
+- 0.7.0 (2026-02-01): 
+  - Implemented client-side message expansion/collapse for better UX.
 
-- 0.6.0 (2026-01-31): Added entity selection feature with visual icons for queues, topics, and subscriptions.
+- 0.6.0 (2026-01-31):
+  - Added entity selection feature with visual icons for queues, topics, and subscriptions.
 
-- 0.5.2 (2026-01-24): Added support for setting the connection string through an environment variable.
+- 0.5.2 (2026-01-24): 
+  - Added support for setting the connection string through an environment variable.
 
-- 0.5.1 (2026-01-22): Updated to .NET 10.
+- 0.5.1 (2026-01-22):
+  - Updated to .NET 10.
 
-- 0.5.0 (2025-05-26): Initial version of Service Bus Viewer.
+- 0.5.0 (2025-05-26): 
+  - Initial version.
 
 ## Development
 

--- a/src/ServiceBusViewer.Web/src/components/entities/EntitySidebar.tsx
+++ b/src/ServiceBusViewer.Web/src/components/entities/EntitySidebar.tsx
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { cx } from '../../lib/cx';
 import { getEntityKey } from '../../lib/formatters';
+import { useAppState } from '../../state/AppStateContext';
 import type { EntityIdDto } from '../../types/serviceBus';
 import { useEntityTooltip } from '../layout/EntityTooltipProvider';
 
@@ -12,6 +14,8 @@ interface EntitySidebarProps {
   onSelectEntity?: (entity: EntityIdDto) => Promise<void> | void;
   topicName: string | null;
 }
+
+const entityFilterDelayMilliseconds = 500;
 
 function buildDetailsPath(entity: EntityIdDto): string {
   const searchParams = new URLSearchParams({ name: entity.name, type: entity.type });
@@ -31,19 +35,49 @@ export function EntitySidebar({
   topicName,
 }: EntitySidebarProps) {
   const { bindTooltip } = useEntityTooltip();
-  const queues = availableEntities
+  const {
+    appliedEntityFilterText,
+    entityFilterText,
+    setAppliedEntityFilterText,
+    setEntityFilterText,
+  } = useAppState();
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setAppliedEntityFilterText(entityFilterText.trim().toLocaleLowerCase());
+    }, entityFilterDelayMilliseconds);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [entityFilterText, setAppliedEntityFilterText]);
+
+  const unfilteredQueues = availableEntities
     .filter((entity) => entity.type === 'Queue')
     .sort((left, right) => left.name.localeCompare(right.name));
-  const topics = availableEntities
+  const unfilteredTopics = availableEntities
     .filter((entity) => entity.type === 'Topic')
     .sort((left, right) => left.name.localeCompare(right.name));
-  const subscriptions = availableEntities
+  const unfilteredSubscriptions = availableEntities
     .filter((entity) => entity.type === 'Subscription')
     .sort(
       (left, right) =>
         (left.topicName ?? '').localeCompare(right.topicName ?? '') ||
         left.name.localeCompare(right.name),
     );
+  const isFiltering = appliedEntityFilterText.length > 0;
+  const matchesFilter = (entity: EntityIdDto) =>
+    entity.name.toLocaleLowerCase().includes(appliedEntityFilterText);
+  const queues = isFiltering ? unfilteredQueues.filter(matchesFilter) : unfilteredQueues;
+  const subscriptions = isFiltering
+    ? unfilteredSubscriptions.filter(matchesFilter)
+    : unfilteredSubscriptions;
+  const matchingSubscriptionTopics = new Set(
+    subscriptions.map((subscription) => subscription.topicName),
+  );
+  const topics = isFiltering
+    ? unfilteredTopics.filter(
+        (topic) => matchesFilter(topic) || matchingSubscriptionTopics.has(topic.name),
+      )
+    : unfilteredTopics;
 
   return (
     <aside className="flex w-full shrink-0 flex-col border-b border-slate-200 bg-slate-50 dark:border-zinc-800 dark:bg-zinc-950 lg:w-64 lg:border-r lg:border-b-0">
@@ -54,10 +88,36 @@ export function EntitySidebar({
         <div className="pointer-events-none absolute right-3 bottom-0 left-3 h-px bg-slate-200 dark:bg-zinc-800" />
       </div>
 
+      <div className="px-3 pt-3">
+        <label className="relative block">
+          <span className="sr-only">Filter entities</span>
+          <span
+            className="material-icons-round pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-[18px] text-slate-400 dark:text-slate-500"
+            aria-hidden="true"
+          >
+            search
+          </span>
+          <input
+            type="search"
+            className="block w-full rounded-lg border border-slate-200 bg-white py-2 pr-3 pl-9 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-zinc-800 dark:bg-zinc-900 dark:text-slate-100 dark:shadow-black/20 dark:placeholder:text-slate-500 dark:focus:border-brand-400"
+            placeholder="Filter entities"
+            value={entityFilterText}
+            onChange={(event) => setEntityFilterText(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                setAppliedEntityFilterText(
+                  event.currentTarget.value.trim().toLocaleLowerCase(),
+                );
+              }
+            }}
+          />
+        </label>
+      </div>
+
       <nav className="custom-scrollbar flex-1 space-y-1 overflow-y-auto p-2">
         {queues.length === 0 && topics.length === 0 ? (
           <div className="rounded border border-dashed border-slate-300 bg-white/80 px-4 py-6 text-center text-sm text-slate-500 dark:border-zinc-700 dark:bg-zinc-900/60 dark:text-slate-400">
-            No entities available
+            {isFiltering ? 'No entities match your filter' : 'No entities available'}
           </div>
         ) : null}
 
@@ -151,48 +211,54 @@ export function EntitySidebar({
                       ) : null}
                     </div>
 
-                    <div className="ml-4 mt-0.5 space-y-0.5 border-l-2 border-slate-200 pl-3 dark:border-zinc-800">
-                      {topicSubscriptions.map((subscription) => {
-                        const isActiveSubscription =
-                          entityName === subscription.name && topicName === subscription.topicName;
-                        const entityKey = getEntityKey(subscription);
+                    {topicSubscriptions.length > 0 ? (
+                      <div className="ml-4 mt-0.5 space-y-0.5 border-l-2 border-slate-200 pl-3 dark:border-zinc-800">
+                        {topicSubscriptions.map((subscription) => {
+                          const isActiveSubscription =
+                            entityName === subscription.name &&
+                            topicName === subscription.topicName;
+                          const entityKey = getEntityKey(subscription);
 
-                        return (
-                          <div key={entityKey} className="flex items-stretch justify-between gap-1 text-sm">
-                            <button
-                              type="button"
-                              className={cx(
-                                'flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left transition',
-                                isActiveSubscription
-                                  ? 'bg-brand-50 font-medium text-brand-600 dark:bg-brand-500/20 dark:text-brand-100'
-                                  : 'text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-zinc-800',
-                              )}
-                              disabled={!onSelectEntity || activeSelectionKey === entityKey}
-                              onClick={() => {
-                                if (onSelectEntity) {
-                                  void onSelectEntity(subscription);
-                                }
-                              }}
-                              {...bindTooltip(subscription.name)}
+                          return (
+                            <div
+                              key={entityKey}
+                              className="flex items-stretch justify-between gap-1 text-sm"
                             >
-                              <span className="material-icons-round text-sm">subtitles</span>
-                              <span className="min-w-0 truncate">{subscription.name}</span>
-                            </button>
-
-                            {displayPropertyLinks ? (
-                              <Link
-                                className="inline-flex h-6 w-6 shrink-0 items-center justify-center self-center rounded text-slate-400 transition hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-zinc-700 dark:hover:text-slate-100"
-                                title="View subscription properties"
-                                aria-label="View subscription properties"
-                                to={buildDetailsPath(subscription)}
+                              <button
+                                type="button"
+                                className={cx(
+                                  'flex min-w-0 flex-1 items-center gap-2 rounded px-2 py-1.5 text-left transition',
+                                  isActiveSubscription
+                                    ? 'bg-brand-50 font-medium text-brand-600 dark:bg-brand-500/20 dark:text-brand-100'
+                                    : 'text-slate-600 hover:bg-slate-200 dark:text-slate-300 dark:hover:bg-zinc-800',
+                                )}
+                                disabled={!onSelectEntity || activeSelectionKey === entityKey}
+                                onClick={() => {
+                                  if (onSelectEntity) {
+                                    void onSelectEntity(subscription);
+                                  }
+                                }}
+                                {...bindTooltip(subscription.name)}
                               >
-                                <span className="material-icons-round text-[18px]">info</span>
-                              </Link>
-                            ) : null}
-                          </div>
-                        );
-                      })}
-                    </div>
+                                <span className="material-icons-round text-sm">subtitles</span>
+                                <span className="min-w-0 truncate">{subscription.name}</span>
+                              </button>
+
+                              {displayPropertyLinks ? (
+                                <Link
+                                  className="inline-flex h-6 w-6 shrink-0 items-center justify-center self-center rounded text-slate-400 transition hover:bg-slate-200 hover:text-slate-700 dark:hover:bg-zinc-700 dark:hover:text-slate-100"
+                                  title="View subscription properties"
+                                  aria-label="View subscription properties"
+                                  to={buildDetailsPath(subscription)}
+                                >
+                                  <span className="material-icons-round text-[18px]">info</span>
+                                </Link>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ) : null}
                   </div>
                 );
               })}

--- a/src/ServiceBusViewer.Web/src/state/AppStateContext.tsx
+++ b/src/ServiceBusViewer.Web/src/state/AppStateContext.tsx
@@ -14,9 +14,13 @@ import type { SessionStateDto, ViewerState } from '../types/serviceBus';
 
 interface AppStateContextValue {
   sessionState: SessionStateDto | null;
+  appliedEntityFilterText: string;
+  entityFilterText: string;
   errorMessages: string[];
   isLoading: boolean;
   refreshSessionState: () => Promise<SessionStateDto>;
+  setAppliedEntityFilterText: (filterText: string) => void;
+  setEntityFilterText: (filterText: string) => void;
   setViewerState: (viewer: ViewerState | null) => void;
 }
 
@@ -24,6 +28,8 @@ const AppStateContext = createContext<AppStateContextValue | null>(null);
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
   const [sessionState, setSessionState] = useState<SessionStateDto | null>(null);
+  const [appliedEntityFilterText, setAppliedEntityFilterText] = useState('');
+  const [entityFilterText, setEntityFilterText] = useState('');
   const [errorMessages, setErrorMessages] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const hasLoadedRef = useRef(false);
@@ -34,6 +40,10 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
     try {
       const nextSessionState = await serviceBusApi.getSessionState();
       setSessionState(nextSessionState);
+      if (!nextSessionState.isConnected) {
+        setAppliedEntityFilterText('');
+        setEntityFilterText('');
+      }
       setErrorMessages([]);
       return nextSessionState;
     } catch (error: unknown) {
@@ -73,12 +83,24 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AppStateContextValue>(
     () => ({
       sessionState,
+      appliedEntityFilterText,
+      entityFilterText,
+      errorMessages,
+      isLoading,
+      refreshSessionState,
+      setAppliedEntityFilterText,
+      setEntityFilterText,
+      setViewerState,
+    }),
+    [
+      sessionState,
+      appliedEntityFilterText,
+      entityFilterText,
       errorMessages,
       isLoading,
       refreshSessionState,
       setViewerState,
-    }),
-    [sessionState, errorMessages, isLoading, refreshSessionState, setViewerState],
+    ],
   );
 
   return (

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>30.0.1</Version>
+		<Version>0.31.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
 - case-insensitive entities filtering
 - preserve filter state across viewer and entity details pages
 - retain topic hierarchy for matching subscriptions