### PR TITLE
Bugfix make entity selection atomic

### DIFF
--- a/.agents/specs/PROJECT_DECISIONS.md
+++ b/.agents/specs/PROJECT_DECISIONS.md
@@ -1,5 +1,11 @@
 # Project Decisions
 
+## 2026-08-12: Direct-entity access excludes standalone topics
+
+- Direct-entity mode supports queues and topic subscriptions. A standalone topic is not a valid direct target because messages cannot be peeked or received from a topic itself.
+- Without management access, `QueueOrTopicName` identifies a queue when `SubscriptionName` is absent and identifies the parent topic when `SubscriptionName` is present.
+- Namespace mode can still select discovered topics, including for sending messages.
+
 ## 2026-08-12: Send completion and message refresh are separate operations
 
 - `POST /api/viewer/send` completes only after the Service Bus send succeeds and returns `204 No Content`; immediate visibility in the peeked-message list is not part of the send contract.
@@ -12,7 +18,7 @@
 - The primary connection string is always used for message operations and is also used for Azure entity discovery when its credential has Manage permission.
 - Azure management capability is detected by entity enumeration. Only explicit authorization failures fall back to direct-entity mode; connectivity, timeout, credential-format, and service failures remain visible.
 - The optional emulator management connection string is accepted only when both strings declare `UseDevelopmentEmulator=true`; emulator messaging endpoints are never probed for management.
-- Direct-entity mode requires a queue or topic only after management is known to be unavailable, allowing the connection page to submit Azure credentials without an entity name.
+- Direct-entity mode requires a queue, or a topic and subscription pair, only after management is known to be unavailable, allowing the connection page to submit Azure credentials without an entity name.
 - The API field is `emulatorManagementConnectionString`. Runtime defaults use the `SERVICEBUSVIEWER_*` environment-variable names with no legacy aliases.
 
 ## 2026-08-09: Kind-specific subscription rule responses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ Enforced rules for agents:
 
 - `SERVICEBUSVIEWER_CONNECTION_STRING` overrides the default primary Service Bus connection string for the API.
 - `SERVICEBUSVIEWER_EMULATOR_MANAGEMENT_CONNECTION_STRING` optionally supplies the emulator-only administration endpoint.
-- `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME` selects the queue or topic used for direct entity access.
-- `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` selects the subscription when direct entity access targets a topic.
+- `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME` selects a queue for direct access, or the parent topic when a subscription is also configured.
+- `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` optionally selects a subscription under the configured parent topic; standalone topic access is not supported without management access.
 - `ASPNETCORE_URLS` can be used to pin the backend port for local development and container scenarios.
 - `VITE_PROXY_TARGET` should match the backend URL when running the SPA separately.
 - `VITE_API_BASE_PATH` sets the API base path embedded in the SPA during Vite development or build and defaults to `/api`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Service Bus Viewer Version History
 
-## 0.40.1 (2026-08-12)
+## 0.40.2 (2026-08-12)
 
+- **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
 - 
 ## 0.40.0 (2026-08-12)

--- a/README.md
+++ b/README.md
@@ -84,26 +84,20 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
 
 ## Version history
 
-## 0.40.1 (2026-08-12)
-  - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
+## 0.40.2 (2026-08-12)
 
-- 0.40.0 (2026-08-12):
-  - **Breaking:** Renamed runtime configuration to `SERVICEBUSVIEWER_CONNECTION_STRING`, `SERVICEBUSVIEWER_EMULATOR_MANAGEMENT_CONNECTION_STRING`, `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME`, and `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` with no legacy aliases.
-  - **Added:** An entity sidebar filter with debounced input, immediate application on Enter, and state preserved between viewer and entity details pages.
-  - **Changed:** Unified Azure connection handling so one Manage-capable connection string is used for entity discovery and message operations, with automatic fallback to direct entity access when management is unauthorized.
-  - **Changed:** Reserved the optional second connection string for emulator management and renamed it to **Emulator Management Connection String** throughout the API and UI.
-  - **Fixed:** Failed connection attempts during initial message peeking no longer leave the browser session marked as connected, allowing immediate retry with corrected credentials.
-  - **Fixed:** A queue, topic, or subscription supplied with a management-capable connection is retained as the initial viewer selection.
-  - **Fixed:** Long expanded message bodies increasing the width of the Peeked Messages table.
+- **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
+- **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
 
-- 0.30.0 (2026-08-09):
-  - Replaced the Razor UI with a React + Vite SPA and reorganized the backend as a minimal API.
-  - Isolated viewer state and Service Bus connections by browser session.
-  - Added centralized RFC `ProblemDetails` API error handling.
-  - Consolidated production deployment into one ASP.NET Core container that serves both the SPA and API.
+## 0.40.0 (2026-08-12)
 
-- 0.11.1 (2026-08-04):
-  - Fixed failed connection attempts leaving the app stuck in a connected state. You can now retry immediately with a corrected connection string.
+- **Breaking:** Renamed runtime configuration to `SERVICEBUSVIEWER_CONNECTION_STRING`, `SERVICEBUSVIEWER_EMULATOR_MANAGEMENT_CONNECTION_STRING`, `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME`, and `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` with no legacy aliases.
+- **Added:** An entity sidebar filter with debounced input, immediate application on Enter, and state preserved between viewer and entity details pages.
+- **Changed:** Unified Azure connection handling so one Manage-capable connection string is used for entity discovery and message operations, with automatic fallback to direct entity access when management is unauthorized.
+- **Changed:** Reserved the optional second connection string for emulator management and renamed it to **Emulator Management Connection String** throughout the API and UI.
+- **Fixed:** Failed connection attempts during initial message peeking no longer leave the browser session marked as connected, allowing immediate retry with corrected credentials.
+- **Fixed:** A queue, topic, or subscription supplied with a management-capable connection is retained as the initial viewer selection.
+- **Fixed:** Long expanded message bodies increasing the width of the Peeked Messages table.
 
 See the [full changelog](CHANGELOG.md) for the complete version history.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Service Bus Viewer is a browser-based tool for inspecting and working with Azure
 
 ## Features
 
-- Automatically browse an Azure namespace when the primary connection has Manage permission, or connect directly to a queue or topic.
+- Automatically browse an Azure namespace when the primary connection has Manage permission, or connect directly to a queue or subscription.
 - Browse queues, topics, subscriptions, entity properties, and subscription filters.
 - Peek and receive messages from queues or topic subscriptions, including session-enabled entities.
 - View message bodies, system properties, and application properties, with client-side JSON formatting.
@@ -27,9 +27,9 @@ Open `http://localhost:8080`. The container listens on port `8080` and serves th
 ## Connection modes
 
 - **Azure namespace browsing:** enter a Manage-capable **Connection String**. The viewer detects management access automatically, discovers all queues, topics, and subscriptions, and uses the same credential for message operations.
-- **Azure direct entity access:** enter a **Connection String** without Manage permission and a **Queue/Topic Name**. For a topic subscription, also enter the **Subscription Name**; otherwise, the specified entity is treated as a queue.
+- **Azure direct entity access:** enter a **Connection String** without Manage permission and a **Queue/Topic Name**. The name identifies a queue unless you also enter a **Subscription Name**, in which case it identifies the parent topic. Standalone topic access is not supported without management access.
 - **Emulator namespace browsing:** enter the emulator messaging **Connection String** and its optional **Emulator Management Connection String**, normally using port `5300` for management.
-- **Emulator direct entity access:** leave **Emulator Management Connection String** empty and provide a **Queue/Topic Name** with the emulator messaging connection string.
+- **Emulator direct entity access:** leave **Emulator Management Connection String** empty and provide either a queue name or a topic and subscription name with the emulator messaging connection string.
 
 Direct entity access requires Listen permission for peeking and receiving messages and Send permission for sending messages. Azure Manage permission includes both Listen and Send.
 
@@ -43,8 +43,8 @@ Settings entered on the connection page apply to the current browser session. Th
 | --- | --- | --- |
 | `SERVICEBUSVIEWER_CONNECTION_STRING` | Primary connection used for messages and, for Azure, automatic management discovery. | Local emulator connection string |
 | `SERVICEBUSVIEWER_EMULATOR_MANAGEMENT_CONNECTION_STRING` | Optional emulator-only administration connection used to browse and refresh entities. | Not set |
-| `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME` | Queue or topic to open in direct entity mode. | Empty |
-| `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` | Subscription to open when `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME` identifies a topic. | Not set |
+| `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME` | Queue to open directly, or parent topic when a subscription is also configured. | Empty |
+| `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` | Optional subscription to open under the configured parent topic. | Not set |
 
 For example, the following command preconfigures namespace browsing for an emulator running on the Docker host:
 

--- a/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
+++ b/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
@@ -12,6 +12,7 @@
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 
 		<AnalysisLevel>latest</AnalysisLevel>
+		<AnalysisLevel>10.0-recommended</AnalysisLevel>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 

--- a/src/ServiceBusViewer.Web/src/pages/ConnectPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ConnectPage.tsx
@@ -138,7 +138,7 @@ export function ConnectPage() {
 										),
 									},
 									{
-										body: 'Add the optional emulator management endpoint to browse entities, or provide an entity name for direct access.',
+										body: 'Add the optional emulator management endpoint to browse entities, or provide a queue or subscription for direct access.',
 										iconBackground:
 											'bg-amber-100 text-amber-700 dark:bg-amber-950/70 dark:text-amber-300',
 										title: 'Emulator-friendly',
@@ -150,7 +150,7 @@ export function ConnectPage() {
 										),
 									},
 									{
-										body: 'Use one Azure connection string, or provide an entity name when management access is unavailable.',
+										body: 'Use one Azure connection string, or provide a queue or subscription when management access is unavailable.',
 										iconBackground:
 											'bg-brand-100 text-brand-700 dark:bg-brand-900/60 dark:text-brand-300',
 										title: 'Connection modes',
@@ -252,6 +252,9 @@ export function ConnectPage() {
 											value={formState.queueOrTopicName ?? ''}
 											onChange={(event) => handleChange('queueOrTopicName', event)}
 										/>
+										<p className="mt-2 text-xs leading-5 text-slate-500 dark:text-slate-400">
+											Without management access, enter a queue name or pair a topic name with a subscription.
+										</p>
 									</div>
 
 									<div>

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequest.cs
@@ -7,8 +7,11 @@ using System.Collections.Generic;
 /// </summary>
 /// <param name="ConnectionString">Primary connection string.</param>
 /// <param name="EmulatorManagementConnectionString">Optional emulator-only management connection string.</param>
-/// <param name="QueueOrTopicName">Optional queue or topic name to connect to.</param>
-/// <param name="SubscriptionName">Optional subscription name when connecting to a subscription.</param>
+/// <param name="QueueOrTopicName">
+/// Optional queue or topic name. Without management access, this identifies a queue unless
+/// <paramref name="SubscriptionName"/> is also provided, in which case it identifies the parent topic.
+/// </param>
+/// <param name="SubscriptionName">Optional subscription name for direct access through its parent topic.</param>
 internal sealed record ConnectRequest(
 	string ConnectionString,
 	string? EmulatorManagementConnectionString,

--- a/src/ServiceBusViewer/Api/Models/ConnectionSettings.cs
+++ b/src/ServiceBusViewer/Api/Models/ConnectionSettings.cs
@@ -3,8 +3,11 @@ namespace ServiceBusViewer.Api.Models;
 /// <summary>Connection settings returned by session-state and disconnect endpoints.</summary>
 /// <param name="ConnectionString">Primary connection string used to connect to Service Bus.</param>
 /// <param name="EmulatorManagementConnectionString">Optional emulator-only management connection string.</param>
-/// <param name="QueueOrTopicName">Optional default queue or topic name.</param>
-/// <param name="SubscriptionName">Optional subscription name.</param>
+/// <param name="QueueOrTopicName">
+/// Optional queue or topic name. Without management access, this identifies a queue unless
+/// <paramref name="SubscriptionName"/> is also provided, in which case it identifies the parent topic.
+/// </param>
+/// <param name="SubscriptionName">Optional subscription name for direct access through its parent topic.</param>
 internal sealed record ConnectionSettings(
 	string ConnectionString,
 	string? EmulatorManagementConnectionString,

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ConnectionSettings.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ConnectionSettings.cs
@@ -3,8 +3,11 @@ namespace ServiceBusViewer.Business.Viewer.Contracts;
 /// <summary>Represents the settings used to connect to a Service Bus namespace.</summary>
 /// <param name="ConnectionString">Primary Service Bus connection string used for messaging operations.</param>
 /// <param name="EmulatorManagementConnectionString">Optional emulator connection string used for management operations.</param>
-/// <param name="QueueOrTopicName">Optional default queue or topic name to select after connecting.</param>
-/// <param name="SubscriptionName">Optional subscription name when a topic subscription is selected.</param>
+/// <param name="QueueOrTopicName">
+/// Optional queue or topic name to select after connecting. In direct-entity mode, this identifies a queue unless <paramref name="SubscriptionName"/> is also provided, in which
+/// case it identifies the parent topic.
+/// </param>
+/// <param name="SubscriptionName">Optional subscription name for direct access through its parent topic.</param>
 public sealed record ConnectionSettings(
 	string ConnectionString,
 	string? EmulatorManagementConnectionString,

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerEntityService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerEntityService.cs
@@ -14,12 +14,13 @@ internal sealed class ViewerEntityService : IViewerEntityService
 		try {
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			connection.GetEntityProperties(entityId);
+			ReceivedMessageList messages = await connection.PeekMessagesAsync(entityId);
 
 			session.SelectedEntityId = entityId;
+			session.CurrentMessages = messages;
 			session.DisplayedMessage = null;
 			session.SendResultMessage = null;
 			session.ReceiveSessionId = null;
-			session.CurrentMessages = await connection.PeekMessagesAsync(entityId);
 
 			return session.ToViewerState(connection);
 		}

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
@@ -61,7 +61,7 @@ internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 	private static ServiceBusConnection CreateScopedEntityConnection(ServiceBusClient client, ConnectionSettings settings, string namespaceHost)
 	{
 		if (string.IsNullOrWhiteSpace(settings.QueueOrTopicName))
-			throw new ArgumentException("Queue or topic name is required because Service Bus management is unavailable. Provide a queue or topic name and try again.");
+			throw new ArgumentException("A queue name, or a topic name with a subscription name, is required because Service Bus management is unavailable.");
 
 		List<EntityProperties> availableEntities = [];
 

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,12 +6,13 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.1</Version>
+		<Version>0.40.2</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>
 
 		<AnalysisLevel>latest</AnalysisLevel>
+		<AnalysisLevel>10.0-recommended</AnalysisLevel>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>


### PR DESCRIPTION
- **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
- **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.