### PR TITLE
fix(viewer): cancel in-flight Service Bus operations on disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Service Bus Viewer Version History
 
-## 0.40.2 (2026-08-12)
+## 0.40.3 (2026-08-13)
 
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
 

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
 
 ## Version history
 
-## 0.40.2 (2026-08-12)
+## 0.40.3 (2026-08-13)
 
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
 

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequestHandler.cs
@@ -9,7 +9,8 @@ internal static class ConnectRequestHandler
 	public static async Task<IResult> HandleAsync(
 		HttpContext context,
 		ConnectRequest request,
-		ServiceBusViewer.Business.Viewer.Contracts.IViewerConnectionService service)
+		ServiceBusViewer.Business.Viewer.Contracts.IViewerConnectionService service,
+		CancellationToken cancellationToken)
 	{
 		Dictionary<string, string[]> errors = [];
 
@@ -29,7 +30,8 @@ internal static class ConnectRequestHandler
 
 		ServiceBusViewer.Business.Viewer.Contracts.ViewerState result = await service.ConnectAsync(
 			context.GetClientSessionState(),
-			settings);
+			settings,
+			cancellationToken);
 
 		return TypedResults.Ok(ToConnectResponse(result));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Disconnect/DisconnectRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Disconnect/DisconnectRequestHandler.cs
@@ -7,9 +7,9 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class DisconnectRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service, IApplicationInfoProvider applicationInfoProvider)
+	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service, IApplicationInfoProvider applicationInfoProvider, CancellationToken cancellationToken)
 	{
-		ViewerConnectionSnapshot viewerConnectionSnapshot = await service.DisconnectAsync(context.GetClientSessionState());
+		ViewerConnectionSnapshot viewerConnectionSnapshot = await service.DisconnectAsync(context.GetClientSessionState(), cancellationToken);
 
 		return TypedResults.Ok(new DisconnectResponse(
 				applicationInfoProvider.ApplicationVersion,

--- a/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsRequestHandler.cs
@@ -8,7 +8,7 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class DetailsRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, [AsParameters] DetailsRequest request, IViewerEntityService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, [AsParameters] DetailsRequest request, IViewerEntityService service, CancellationToken cancellationToken)
 	{
 		Dictionary<string, string[]> errors = [];
 
@@ -24,7 +24,8 @@ internal static class DetailsRequestHandler
 
 		EntityDetailsResult result = await service.GetDetailsAsync(
 			context.GetClientSessionState(),
-			entityId);
+			entityId,
+			cancellationToken);
 
 		return TypedResults.Ok(ToDetailsResponse(result));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/SessionState/GetSessionState/GetSessionStateRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/SessionState/GetSessionState/GetSessionStateRequestHandler.cs
@@ -7,9 +7,9 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class GetSessionStateRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service, IApplicationInfoProvider applicationInfoProvider)
+	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service, IApplicationInfoProvider applicationInfoProvider, CancellationToken cancellationToken)
 	{
-		ViewerConnectionSnapshot viewerConnectionSnapshot = await service.GetSnapshotAsync(context.GetClientSessionState());
+		ViewerConnectionSnapshot viewerConnectionSnapshot = await service.GetSnapshotAsync(context.GetClientSessionState(), cancellationToken);
 
 		return TypedResults.Ok(new SessionStateResponse(
 				applicationInfoProvider.ApplicationVersion,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/GetViewer/GetViewerRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/GetViewer/GetViewerRequestHandler.cs
@@ -6,9 +6,9 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class GetViewerRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, IViewerConnectionService service, CancellationToken cancellationToken)
 	{
-		ServiceBusViewer.Business.Viewer.Contracts.ViewerState state = await service.GetCurrentStateAsync(context.GetClientSessionState());
+		ServiceBusViewer.Business.Viewer.Contracts.ViewerState state = await service.GetCurrentStateAsync(context.GetClientSessionState(), cancellationToken);
 
 		return TypedResults.Ok(ToGetViewerResponse(state));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveRequestHandler.cs
@@ -6,7 +6,7 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class ReceiveRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, ReceiveRequest request, IViewerMessageService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, ReceiveRequest request, IViewerMessageService service, CancellationToken cancellationToken)
 	{
 		Dictionary<string, string[]> errors = [];
 		if (!ReceiveRequestValidator.Validate(request, out IReadOnlyDictionary<string, string[]>? receiveErrors) && receiveErrors is not null) {
@@ -17,7 +17,7 @@ internal static class ReceiveRequestHandler
 		if (errors.Count > 0)
 			return Results.ValidationProblem(errors, statusCode: StatusCodes.Status400BadRequest, title: "Validation failed");
 
-		ServiceBusViewer.Business.Viewer.Contracts.ViewerState result = await service.ReceiveAsync(context.GetClientSessionState(), request.ReceiveSessionId);
+		ServiceBusViewer.Business.Viewer.Contracts.ViewerState result = await service.ReceiveAsync(context.GetClientSessionState(), request.ReceiveSessionId, cancellationToken);
 
 		return TypedResults.Ok(ToReceiveResponse(result));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Refresh/RefreshRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Refresh/RefreshRequestHandler.cs
@@ -6,9 +6,9 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class RefreshRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, IViewerMessageService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, IViewerMessageService service, CancellationToken cancellationToken)
 	{
-		ServiceBusViewer.Business.Viewer.Contracts.ViewerState state = await service.RefreshAsync(context.GetClientSessionState());
+		ServiceBusViewer.Business.Viewer.Contracts.ViewerState state = await service.RefreshAsync(context.GetClientSessionState(), cancellationToken);
 
 		return TypedResults.Ok(ToRefreshResponse(state));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityRequestHandler.cs
@@ -7,7 +7,7 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class SelectEntityRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, SelectEntityRequest request, IViewerEntityService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, SelectEntityRequest request, IViewerEntityService service, CancellationToken cancellationToken)
 	{
 		Dictionary<string, string[]> errors = [];
 
@@ -33,7 +33,8 @@ internal static class SelectEntityRequestHandler
 
 		ServiceBusViewer.Business.Viewer.Contracts.ViewerState result = await service.SelectEntityAsync(
 			context.GetClientSessionState(),
-			entityId);
+			entityId,
+			cancellationToken);
 
 		return TypedResults.Ok(ToSelectEntityResponse(result));
 	}

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
@@ -9,7 +9,7 @@ using ServiceBusViewer.Infrastructure.ClientSession;
 
 internal static class SendRequestHandler
 {
-	public static async Task<IResult> HandleAsync(HttpContext context, SendRequest request, IViewerMessageService service)
+	public static async Task<IResult> HandleAsync(HttpContext context, SendRequest request, IViewerMessageService service, CancellationToken cancellationToken)
 	{
 		Dictionary<string, string[]> errors = [];
 
@@ -30,7 +30,8 @@ internal static class SendRequestHandler
 
 		await service.SendAsync(
 			context.GetClientSessionState(),
-			new SendCommand(request.SendMessageBody ?? string.Empty, messageProperties, applicationProperties));
+			new SendCommand(request.SendMessageBody ?? string.Empty, messageProperties, applicationProperties),
+			cancellationToken);
 
 		return TypedResults.NoContent();
 	}

--- a/src/ServiceBusViewer/Api/ExceptionHandling/ApiExceptionHandler.cs
+++ b/src/ServiceBusViewer/Api/ExceptionHandling/ApiExceptionHandler.cs
@@ -23,6 +23,9 @@ internal sealed class ApiExceptionHandler(
 	/// <returns><see langword="true"/> when the exception response was written; otherwise, <see langword="false"/>.</returns>
 	public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
 	{
+		if (exception is OperationCanceledException && httpContext.RequestAborted.IsCancellationRequested)
+			return false;
+
 		ExceptionResponse response = ClassifyException(exception);
 
 		if (response.IsUnexpected)
@@ -65,6 +68,7 @@ internal sealed class ApiExceptionHandler(
 		=> exception switch {
 			ViewerAlreadyConnectedException => new ExceptionResponse(StatusCodes.Status409Conflict, "Already connected", exception.Message, false),
 			ViewerNotConnectedException => new ExceptionResponse(StatusCodes.Status409Conflict, "Not connected", exception.Message, false),
+			OperationCanceledException => new ExceptionResponse(StatusCodes.Status409Conflict, "Operation cancelled", "The Service Bus operation was cancelled because the viewer disconnected.", false),
 			ArgumentException or FormatException => new ExceptionResponse(StatusCodes.Status400BadRequest, "Invalid request", exception.Message, false),
 			RequestFailedException or ServiceBusException => new ExceptionResponse(
 				StatusCodes.Status400BadRequest,

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerConnectionService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerConnectionService.cs
@@ -7,24 +7,28 @@ public interface IViewerConnectionService
 {
 	/// <summary>Gets the current connection snapshot for the viewer session.</summary>
 	/// <param name="session">The viewer session state to read.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The current connection snapshot.</returns>
-	Task<ViewerConnectionSnapshot> GetSnapshotAsync(IViewerSessionState session);
+	Task<ViewerConnectionSnapshot> GetSnapshotAsync(IViewerSessionState session, CancellationToken cancellationToken);
 
 	/// <summary>Opens a Service Bus connection for the viewer session.</summary>
 	/// <param name="session">The viewer session state to update.</param>
 	/// <param name="settings">Connection settings provided by the client.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The resulting viewer state after the connection is established.</returns>
-	Task<ViewerState> ConnectAsync(IViewerSessionState session, ConnectionSettings settings);
+	Task<ViewerState> ConnectAsync(IViewerSessionState session, ConnectionSettings settings, CancellationToken cancellationToken);
 
 	/// <summary>Disconnects the current Service Bus connection and clears connection-scoped viewer state.</summary>
 	/// <param name="session">The viewer session state to reset.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The resulting disconnected snapshot.</returns>
-	Task<ViewerConnectionSnapshot> DisconnectAsync(IViewerSessionState session);
+	Task<ViewerConnectionSnapshot> DisconnectAsync(IViewerSessionState session, CancellationToken cancellationToken);
 
 	/// <summary>Gets the current viewer state for a connected session.</summary>
 	/// <param name="session">The viewer session state to read.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The current viewer state.</returns>
-	Task<ViewerState> GetCurrentStateAsync(IViewerSessionState session);
+	Task<ViewerState> GetCurrentStateAsync(IViewerSessionState session, CancellationToken cancellationToken);
 }
 
 /// <summary>Represents the current connection state for a viewer session.</summary>

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerEntityService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerEntityService.cs
@@ -9,12 +9,14 @@ public interface IViewerEntityService
 	/// <summary>Selects the active entity for subsequent viewer operations.</summary>
 	/// <param name="session">The viewer session state to update.</param>
 	/// <param name="entityId">The entity to select.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The resulting viewer state after selection.</returns>
-	Task<ViewerState> SelectEntityAsync(IViewerSessionState session, EntityId entityId);
+	Task<ViewerState> SelectEntityAsync(IViewerSessionState session, EntityId entityId, CancellationToken cancellationToken);
 
 	/// <summary>Gets detailed metadata for a specific entity.</summary>
 	/// <param name="session">The viewer session state used for the lookup.</param>
 	/// <param name="entityId">The entity to describe.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>Detailed information about the requested entity.</returns>
-	Task<EntityDetailsResult> GetDetailsAsync(IViewerSessionState session, EntityId entityId);
+	Task<EntityDetailsResult> GetDetailsAsync(IViewerSessionState session, EntityId entityId, CancellationToken cancellationToken);
 }

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerMessageService.cs
@@ -7,17 +7,20 @@ public interface IViewerMessageService
 {
 	/// <summary>Refreshes the message list for the currently selected entity.</summary>
 	/// <param name="session">The viewer session state to update.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>The refreshed viewer state.</returns>
-	Task<ViewerState> RefreshAsync(IViewerSessionState session);
+	Task<ViewerState> RefreshAsync(IViewerSessionState session, CancellationToken cancellationToken);
 
 	/// <summary>Receives the next message from the currently selected entity.</summary>
 	/// <param name="session">The viewer session state to update.</param>
 	/// <param name="sessionId">Optional Service Bus session identifier used when the selected entity is session-enabled.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>TThe viewer state after attempting to receive a message.</returns>
-	Task<ViewerState> ReceiveAsync(IViewerSessionState session, string? sessionId);
+	Task<ViewerState> ReceiveAsync(IViewerSessionState session, string? sessionId, CancellationToken cancellationToken);
 
 	/// <summary>Sends a message to the currently selected entity.</summary>
 	/// <param name="session">The viewer session state to use.</param>
 	/// <param name="command">The message body and properties to send.</param>
-	Task SendAsync(IViewerSessionState session, SendCommand command);
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
+	Task SendAsync(IViewerSessionState session, SendCommand command, CancellationToken cancellationToken);
 }

--- a/src/ServiceBusViewer/Business/Viewer/Dependencies/IServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Dependencies/IServiceBusConnection.cs
@@ -23,8 +23,9 @@ public interface IServiceBusConnection : IAsyncDisposable
 	IReadOnlyList<EntityProperties> AvailableEntities { get; }
 
 	/// <summary>Refreshes the catalog of available entities from the management API.</summary>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>A task that completes when the refresh finishes.</returns>
-	Task RefreshEntitiesAsync();
+	Task RefreshEntitiesAsync(CancellationToken cancellationToken);
 
 	/// <summary>Retrieves the properties for a specific entity previously discovered.</summary>
 	/// <param name="entityId">The identity of the entity whose properties are requested.</param>
@@ -34,18 +35,21 @@ public interface IServiceBusConnection : IAsyncDisposable
 	/// <summary>Peeks up to <paramref name="maxMessages"/> messages from the requested entity without removing them from the queue/topic subscription.</summary>
 	/// <param name="entityId">Identifier of the entity to peek.</param>
 	/// <param name="maxMessages">Maximum number of messages to peek. Defaults to 50.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>A task that completes with the list of peeked messages.</returns>
-	Task<ReceivedMessageList> PeekMessagesAsync(EntityId entityId, int maxMessages = 50);
+	Task<ReceivedMessageList> PeekMessagesAsync(EntityId entityId, int maxMessages, CancellationToken cancellationToken);
 
 	/// <summary>Receives the next available message from the requested entity.</summary>
 	/// <param name="entityId">Identifier of the entity to receive from.</param>
 	/// <param name="sessionId">Session id to receive from, or <c>null</c> for non-session receive or next available session.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>A task that completes with the received message or <c>null</c> if none available.</returns>
-	Task<ReceivedMessage?> ReceiveMessageAsync(EntityId entityId, string? sessionId = null);
+	Task<ReceivedMessage?> ReceiveMessageAsync(EntityId entityId, string? sessionId, CancellationToken cancellationToken);
 
 	/// <summary>Sends a message to the requested entity.</summary>
 	/// <param name="entityId">Identifier of the entity to send to.</param>
 	/// <param name="command">Command containing the message body and associated properties.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
 	/// <returns>A task that completes when the send operation completes.</returns>
-	Task SendMessageAsync(EntityId entityId, SendCommand command);
+	Task SendMessageAsync(EntityId entityId, SendCommand command, CancellationToken cancellationToken);
 }

--- a/src/ServiceBusViewer/Business/Viewer/Dependencies/IServiceBusConnectionFactory.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Dependencies/IServiceBusConnectionFactory.cs
@@ -2,19 +2,12 @@ namespace ServiceBusViewer.Business.Viewer.Dependencies;
 
 using ServiceBusViewer.Business.Viewer.Contracts;
 
-/// <summary>
-/// Creates open Service Bus connections from viewer connection settings.
-/// </summary>
+/// <summary>Creates open Service Bus connections from viewer connection settings.</summary>
 public interface IServiceBusConnectionFactory
 {
-	/// <summary>
-	/// Opens a connection for the given viewer connection settings.
-	/// </summary>
-	/// <param name="settings">
-	/// Viewer-provided connection settings describing the Service Bus namespace and credentials.
-	/// </param>
-	/// <returns>
-	/// A task that completes with an <see cref="IServiceBusConnection"/> representing the opened connection.
-	/// </returns>
-	Task<IServiceBusConnection> OpenAsync(ConnectionSettings settings);
+	/// <summary>Opens a connection for the given viewer connection settings.</summary>
+	/// <param name="settings">Viewer-provided connection settings describing the Service Bus namespace and credentials.</param>
+	/// <param name="cancellationToken">Optional <seealso cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.</param>
+	/// <returns>A task that completes with an <see cref="IServiceBusConnection"/> representing the opened connection.</returns>
+	Task<IServiceBusConnection> OpenAsync(ConnectionSettings settings, CancellationToken cancellationToken);
 }

--- a/src/ServiceBusViewer/Business/Viewer/Dependencies/IViewerSessionState.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Dependencies/IViewerSessionState.cs
@@ -4,17 +4,18 @@ using ServiceBusViewer.Business.Viewer.Contracts;
 using ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 
 /// <summary>
-/// Represents the business-facing state for a single browser session. Implementations are owned by infrastructure but
-/// the interface lives with Business contracts so business logic depends on the abstraction rather than a concrete
-/// implementation.
+/// Represents the business-facing state for a single browser session. Implementations are owned by infrastructure but the interface lives with Business contracts so business logic
+/// depends on the abstraction rather than a concrete implementation.
 /// </summary>
 public interface IViewerSessionState : IAsyncDisposable
 {
 	/// <summary>
-	/// A session-wide gate to serialize access to mutable session state. Use <see cref="SemaphoreSlim.WaitAsync()"/> and
-	/// <see cref="SemaphoreSlim.Release()"/> or a helper wrapper.
+	/// A session-wide gate to serialize access to mutable session state. Use <see cref="SemaphoreSlim.WaitAsync()"/> and <see cref="SemaphoreSlim.Release()"/> or a helper wrapper.
 	/// </summary>
 	SemaphoreSlim Gate { get; }
+
+	/// <summary>Signals when disconnecting or expiring the current Service Bus connection.</summary>
+	CancellationToken ConnectionCancellationToken { get; }
 
 	/// <summary>
 	/// Current connection settings used to open the Service Bus connection for this session.
@@ -57,10 +58,12 @@ public interface IViewerSessionState : IAsyncDisposable
 	bool IsConnected { get; }
 
 	/// <summary>
-	/// Resets and clears any connection-related state for the session (invoked on explicit disconnect or errors).
-	/// Implementations should dispose the underlying <see cref="IServiceBusConnection"/> if present and clear message
-	/// caches.
+	/// Resets and clears any connection-related state for the session (invoked on explicit disconnect or errors). Implementations should dispose the underlying
+	/// <see cref="IServiceBusConnection"/> if present and clear message caches.
 	/// </summary>
 	/// <returns>A task that completes when the reset operation finishes.</returns>
 	Task ResetConnectionAsync();
+
+	/// <summary>Cancels in-flight operations that use the current Service Bus connection.</summary>
+	void CancelActiveConnectionOperations();
 }

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerConnectionService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerConnectionService.cs
@@ -7,9 +7,9 @@ using ServiceBusViewer.Business.Viewer.Dependencies;
 /// <summary>Coordinates connection lifecycle operations for a single browser session.</summary>
 internal sealed class ViewerConnectionService(IServiceBusConnectionFactory connectionFactory) : IViewerConnectionService
 {
-	public async Task<ViewerConnectionSnapshot> GetSnapshotAsync(IViewerSessionState session)
+	public async Task<ViewerConnectionSnapshot> GetSnapshotAsync(IViewerSessionState session, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
 			return session.ToViewerConnectionSnapshot();
@@ -19,23 +19,24 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 		}
 	}
 
-	public async Task<ViewerState> ConnectAsync(IViewerSessionState session, ConnectionSettings settings)
+	public async Task<ViewerState> ConnectAsync(IViewerSessionState session, ConnectionSettings settings, CancellationToken cancellationToken)
 	{
 		ArgumentNullException.ThrowIfNull(settings);
 
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
+			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
 			if (session.IsConnected)
 				throw new ViewerAlreadyConnectedException();
 
-			IServiceBusConnection connection = await connectionFactory.OpenAsync(settings);
+			IServiceBusConnection connection = await connectionFactory.OpenAsync(settings, operationCancellationSource.Token);
 
 			try {
 				EntityId? selectedEntityId = GetInitialSelectedEntityId(settings, connection.AvailableEntities);
 				ReceivedMessageList currentMessages = selectedEntityId is null
 					? ReceivedMessageList.Empty
-					: await connection.PeekMessagesAsync(selectedEntityId);
+					: await connection.PeekMessagesAsync(selectedEntityId, 50, operationCancellationSource.Token);
 
 				session.ConnectionSettings = settings;
 				session.Connection = connection;
@@ -57,9 +58,11 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 		}
 	}
 
-	public async Task<ViewerConnectionSnapshot> DisconnectAsync(IViewerSessionState session)
+	public async Task<ViewerConnectionSnapshot> DisconnectAsync(IViewerSessionState session, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		session.CancelActiveConnectionOperations();
+		// Disconnect must complete cleanup after cancelling an in-flight operation, even when its caller aborts the HTTP request.
+		await session.Gate.WaitAsync(CancellationToken.None);
 
 		try {
 			await session.ResetConnectionAsync();
@@ -70,9 +73,9 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 		}
 	}
 
-	public async Task<ViewerState> GetCurrentStateAsync(IViewerSessionState session)
+	public async Task<ViewerState> GetCurrentStateAsync(IViewerSessionState session, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerEntityService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerEntityService.cs
@@ -7,14 +7,16 @@ using ServiceBusViewer.Business.Viewer.Dependencies;
 /// <summary>Coordinates entity selection and details for a single browser session.</summary>
 internal sealed class ViewerEntityService : IViewerEntityService
 {
-	public async Task<ViewerState> SelectEntityAsync(IViewerSessionState session, EntityId entityId)
+	public async Task<ViewerState> SelectEntityAsync(IViewerSessionState session, EntityId entityId, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
+			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
+
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			connection.GetEntityProperties(entityId);
-			ReceivedMessageList messages = await connection.PeekMessagesAsync(entityId);
+			ReceivedMessageList messages = await connection.PeekMessagesAsync(entityId, 50, operationCancellationSource.Token);
 
 			session.SelectedEntityId = entityId;
 			session.CurrentMessages = messages;
@@ -29,9 +31,9 @@ internal sealed class ViewerEntityService : IViewerEntityService
 		}
 	}
 
-	public async Task<EntityDetailsResult> GetDetailsAsync(IViewerSessionState session, EntityId entityId)
+	public async Task<EntityDetailsResult> GetDetailsAsync(IViewerSessionState session, EntityId entityId, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -11,17 +11,19 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 	private readonly ILogger<ViewerMessageService> _logger = logger;
 
 	/// <inheritdoc/>
-	public async Task<ViewerState> RefreshAsync(IViewerSessionState session)
+	public async Task<ViewerState> RefreshAsync(IViewerSessionState session, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
+			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
+			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			EntityId? entityId = session.SelectedEntityId;
 
 			session.CurrentMessages = entityId is null
 				? ReceivedMessageList.Empty
-				: await connection.PeekMessagesAsync(entityId);
+				: await connection.PeekMessagesAsync(entityId, 50, operationCancellationToken);
 
 			bool requiresSession = entityId is not null
 				&& connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
@@ -38,22 +40,27 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 	}
 
 	/// <inheritdoc/>
-	public async Task<ViewerState> ReceiveAsync(IViewerSessionState session, string? sessionId)
+	public async Task<ViewerState> ReceiveAsync(IViewerSessionState session, string? sessionId, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
+			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
+			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
 			bool requiresSession = connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
 				or SubscriptionEntityProperties { RequiresSession: true };
 
 			session.ReceiveSessionId = requiresSession ? sessionId : null;
-			session.DisplayedMessage = await connection.ReceiveMessageAsync(entityId, requiresSession ? sessionId : null);
+			session.DisplayedMessage = await connection.ReceiveMessageAsync(entityId, requiresSession ? sessionId : null, operationCancellationToken);
 			session.SendResultMessage = null;
 
 			try {
-				session.CurrentMessages = await connection.PeekMessagesAsync(entityId);
+				session.CurrentMessages = await connection.PeekMessagesAsync(entityId, 50, operationCancellationToken);
+			}
+			catch (OperationCanceledException) when (operationCancellationToken.IsCancellationRequested) {
+				throw;
 			}
 			catch (Exception exception) {
 				_logger.LogWarning(
@@ -69,17 +76,19 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 	}
 
 	/// <inheritdoc/>
-	public async Task SendAsync(IViewerSessionState session, SendCommand command)
+	public async Task SendAsync(IViewerSessionState session, SendCommand command, CancellationToken cancellationToken)
 	{
-		await session.Gate.WaitAsync();
+		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
+			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
+			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
 			bool requiresSession = connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
 				or SubscriptionEntityProperties { RequiresSession: true };
 
-			await connection.SendMessageAsync(entityId, command);
+			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
 
 			session.DisplayedMessage = null;
 			session.SendResultMessage = BuildSendResultMessage(command.MessageProperties.ContentType, command.MessageProperties.MessageId);

--- a/src/ServiceBusViewer/Infrastructure/ClientSession/ClientSessionState.cs
+++ b/src/ServiceBusViewer/Infrastructure/ClientSession/ClientSessionState.cs
@@ -8,6 +8,7 @@ using ServiceBusViewer.Business.Viewer.Dependencies;
 internal sealed class ClientSessionState : IViewerSessionState
 {
 	private long _lastAccessUnixTimeSeconds;
+	private CancellationTokenSource _connectionCancellationSource = new();
 
 	public ClientSessionState()
 	{
@@ -16,6 +17,11 @@ internal sealed class ClientSessionState : IViewerSessionState
 	}
 
 	public SemaphoreSlim Gate { get; } = new(1, 1);
+
+	public CancellationToken ConnectionCancellationToken => _connectionCancellationSource.Token;
+
+	public void CancelActiveConnectionOperations()
+		=> _connectionCancellationSource.Cancel();
 
 	public ConnectionSettings ConnectionSettings { get; set; }
 
@@ -40,22 +46,34 @@ internal sealed class ClientSessionState : IViewerSessionState
 
 	public async Task ResetConnectionAsync()
 	{
-		if (Connection is not null) {
-			await Connection.DisposeAsync();
-			Connection = null;
-		}
+		IServiceBusConnection? connection = Connection;
+		Connection = null;
+
+		if (connection is not null)
+			await connection.DisposeAsync();
 
 		SelectedEntityId = null;
 		CurrentMessages = ReceivedMessageList.Empty;
 		DisplayedMessage = null;
 		ReceiveSessionId = null;
 		SendResultMessage = null;
+		_connectionCancellationSource.Dispose();
+		_connectionCancellationSource = new CancellationTokenSource();
 	}
 
 	public async ValueTask DisposeAsync()
 	{
-		await ResetConnectionAsync();
-		Gate.Dispose();
+		CancelActiveConnectionOperations();
+		await Gate.WaitAsync();
+
+		try {
+			await ResetConnectionAsync();
+		}
+		finally {
+			Gate.Release();
+			Gate.Dispose();
+			_connectionCancellationSource.Dispose();
+		}
 	}
 
 	private static ConnectionSettings CreateDefaultConnectionSettings()

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -47,7 +47,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 			?? throw new InvalidOperationException($"Entity properties for '{entityId.Name}' not found in cache. Please refresh the entity list.");
 	}
 
-	public async Task<ReceivedMessageList> PeekMessagesAsync(EntityId entityId, int maxMessages = _maxMessagesToPeek)
+	public async Task<ReceivedMessageList> PeekMessagesAsync(EntityId entityId, int maxMessages, CancellationToken cancellationToken)
 	{
 		ThrowIfDisposed();
 
@@ -57,13 +57,13 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 			return ReceivedMessageList.Empty;
 
 		await using ServiceBusReceiver receiver = GetReceiver(entity);
-		IReadOnlyList<ServiceBusReceivedMessage> messages = await receiver.PeekMessagesAsync(maxMessages + 1);
+		IReadOnlyList<ServiceBusReceivedMessage> messages = await receiver.PeekMessagesAsync(maxMessages + 1, cancellationToken: cancellationToken);
 		bool hasMore = messages.Count > maxMessages;
 		IEnumerable<ServiceBusReceivedMessage> messagesToReturn = hasMore ? messages.Take(maxMessages) : messages;
 		return new ReceivedMessageList([.. messagesToReturn.Select(ConvertToReceivedMessage)], hasMore);
 	}
 
-	public async Task<ReceivedMessage?> ReceiveMessageAsync(EntityId entityId, string? sessionId = null)
+	public async Task<ReceivedMessage?> ReceiveMessageAsync(EntityId entityId, string? sessionId, CancellationToken cancellationToken)
 	{
 		ThrowIfDisposed();
 
@@ -76,26 +76,26 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 		if (!requiresSession) {
 			await using ServiceBusReceiver nonSessionReceiver = GetReceiver(entity);
-			ServiceBusReceivedMessage? nonSessionMessage = await nonSessionReceiver.ReceiveMessageAsync();
+			ServiceBusReceivedMessage? nonSessionMessage = await nonSessionReceiver.ReceiveMessageAsync(cancellationToken: cancellationToken);
 
 			if (nonSessionMessage is null)
 				return null;
 
-			await nonSessionReceiver.CompleteMessageAsync(nonSessionMessage);
+			await nonSessionReceiver.CompleteMessageAsync(nonSessionMessage, cancellationToken);
 			return ConvertToReceivedMessage(nonSessionMessage);
 		}
 
-		await using ServiceBusSessionReceiver receiver = await GetSessionReceiver(entity, sessionId);
-		ServiceBusReceivedMessage? message = await receiver.ReceiveMessageAsync();
+		await using ServiceBusSessionReceiver receiver = await GetSessionReceiverAsync(entity, sessionId, cancellationToken);
+		ServiceBusReceivedMessage? message = await receiver.ReceiveMessageAsync(cancellationToken: cancellationToken);
 
 		if (message is null)
 			return null;
 
-		await receiver.CompleteMessageAsync(message);
+		await receiver.CompleteMessageAsync(message, cancellationToken);
 		return ConvertToReceivedMessage(message);
 	}
 
-	public async Task SendMessageAsync(EntityId entityId, SendCommand command)
+	public async Task SendMessageAsync(EntityId entityId, SendCommand command, CancellationToken cancellationToken)
 	{
 		ThrowIfDisposed();
 
@@ -129,10 +129,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				message.ApplicationProperties[property.Key] = ConvertApplicationPropertyValue(property.Value, property.Type);
 		}
 
-		await sender.SendMessageAsync(message);
+		await sender.SendMessageAsync(message, cancellationToken);
 	}
 
-	public async Task RefreshEntitiesAsync()
+	public async Task RefreshEntitiesAsync(CancellationToken cancellationToken)
 	{
 		ThrowIfDisposed();
 
@@ -141,7 +141,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 		_availableEntities.Clear();
 
-		await foreach (QueueProperties queue in _adminClient.GetQueuesAsync()) {
+		await foreach (QueueProperties queue in _adminClient.GetQueuesAsync(cancellationToken)) {
 			_availableEntities.Add(new QueueEntityProperties(
 				queue.Name,
 				queue.LockDuration,
@@ -156,7 +156,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				queue.AutoDeleteOnIdle));
 		}
 
-		await foreach (TopicProperties topic in _adminClient.GetTopicsAsync()) {
+		await foreach (TopicProperties topic in _adminClient.GetTopicsAsync(cancellationToken)) {
 			_availableEntities.Add(new TopicEntityProperties(
 				topic.Name,
 				topic.DefaultMessageTimeToLive,
@@ -166,10 +166,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				topic.EnablePartitioning,
 				topic.AutoDeleteOnIdle));
 
-			await foreach (SubscriptionProperties subscription in _adminClient.GetSubscriptionsAsync(topic.Name)) {
+			await foreach (SubscriptionProperties subscription in _adminClient.GetSubscriptionsAsync(topic.Name, cancellationToken)) {
 				List<SubscriptionFilterRule> rules = [];
 
-				await foreach (RuleProperties rule in _adminClient.GetRulesAsync(topic.Name, subscription.SubscriptionName)) {
+				await foreach (RuleProperties rule in _adminClient.GetRulesAsync(topic.Name, subscription.SubscriptionName, cancellationToken)) {
 					rules.Add(ConvertToSubscriptionRule(rule));
 				}
 
@@ -215,18 +215,18 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 		throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.");
 	}
 
-	private async Task<ServiceBusSessionReceiver> GetSessionReceiver(EntityProperties entity, string? sessionId)
+	private async Task<ServiceBusSessionReceiver> GetSessionReceiverAsync(EntityProperties entity, string? sessionId, CancellationToken cancellationToken)
 	{
 		if (entity is SubscriptionEntityProperties subscription) {
 			return string.IsNullOrWhiteSpace(sessionId)
-				? await _client.AcceptNextSessionAsync(subscription.TopicName, subscription.Name)
-				: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId);
+				? await _client.AcceptNextSessionAsync(subscription.TopicName, subscription.Name, cancellationToken: cancellationToken)
+				: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId, cancellationToken: cancellationToken);
 		}
 
 		if (entity is QueueEntityProperties queue) {
 			return string.IsNullOrWhiteSpace(sessionId)
-				? await _client.AcceptNextSessionAsync(queue.Name)
-				: await _client.AcceptSessionAsync(queue.Name, sessionId);
+				? await _client.AcceptNextSessionAsync(queue.Name, cancellationToken: cancellationToken)
+				: await _client.AcceptSessionAsync(queue.Name, sessionId, cancellationToken: cancellationToken);
 		}
 
 		throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.");

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
@@ -10,7 +10,7 @@ using ServiceBusViewer.Business.Viewer.Dependencies;
 /// <summary>Builds browser-session-scoped Service Bus connections.</summary>
 internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 {
-	public async Task<IServiceBusConnection> OpenAsync(ConnectionSettings settings)
+	public async Task<IServiceBusConnection> OpenAsync(ConnectionSettings settings, CancellationToken cancellationToken)
 	{
 		ArgumentNullException.ThrowIfNull(settings);
 
@@ -29,13 +29,13 @@ internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 					return CreateScopedEntityConnection(client, settings, connectionProperties.FullyQualifiedNamespace);
 
 				ServiceBusAdministrationClient emulatorAdminClient = new(settings.EmulatorManagementConnectionString!);
-				return await CreateNamespaceConnectionAsync(client, emulatorAdminClient, connectionProperties.FullyQualifiedNamespace);
+				return await CreateNamespaceConnectionAsync(client, emulatorAdminClient, connectionProperties.FullyQualifiedNamespace, cancellationToken);
 			}
 
 			ServiceBusAdministrationClient adminClient = new(settings.ConnectionString);
 
 			try {
-				return await CreateNamespaceConnectionAsync(client, adminClient, connectionProperties.FullyQualifiedNamespace);
+				return await CreateNamespaceConnectionAsync(client, adminClient, connectionProperties.FullyQualifiedNamespace, cancellationToken);
 			}
 			catch (Exception exception) when (IsManagementAuthorizationFailure(exception)) {
 				return CreateScopedEntityConnection(client, settings, connectionProperties.FullyQualifiedNamespace);
@@ -50,10 +50,11 @@ internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 	private static async Task<ServiceBusConnection> CreateNamespaceConnectionAsync(
 		ServiceBusClient client,
 		ServiceBusAdministrationClient adminClient,
-		string namespaceHost)
+		string namespaceHost,
+		CancellationToken cancellationToken)
 	{
 		var connection = new ServiceBusConnection(client, adminClient, namespaceHost);
-		await connection.RefreshEntitiesAsync();
+		await connection.RefreshEntitiesAsync(cancellationToken);
 
 		return connection;
 	}

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.2</Version>
+		<Version>0.40.3</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
This pull request improves cancellation handling throughout the Service Bus Viewer API, ensuring that aborted HTTP requests and client disconnects properly cancel in-flight Service Bus operations. This prevents operations from blocking the browser session and provides more accurate error reporting. The changes also update the API contracts to require `CancellationToken` parameters for all relevant service methods.

These changes collectively ensure that the Service Bus Viewer responds promptly to client disconnects and request cancellations, leading to a more robust and responsive user experience.