### PR TITLE
 fix(viewer): move state mapping out of contracts

### DIFF
--- a/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerConnectionService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/IViewerConnectionService.cs
@@ -39,21 +39,3 @@ public sealed record ViewerConnectionSnapshot(
 	ConnectionSettings Connection,
 	ViewerState? Viewer,
 	bool IsConnected);
-
-
-/// <summary>Provides extension methods for <see cref="ViewerConnectionSnapshot"/>.</summary>
-public static class ViewerConnectionSnapshotExtensions
-{
-	/// <summary>
-	/// Creates a <see cref="ViewerConnectionSnapshot"/> from the given <see cref="IViewerSessionState"/>.
-	/// </summary>
-	/// <param name="session">The viewer session state to convert.</param>
-	/// <returns>The resulting <see cref="ViewerConnectionSnapshot"/>.</returns>
-	public static ViewerConnectionSnapshot ToViewerConnectionSnapshot(this IViewerSessionState session)
-		=> new ViewerConnectionSnapshot(
-			session.ConnectionSettings,
-			session.IsConnected
-				? session.ToViewerState(session.Connection!)
-				: null,
-			session.IsConnected);
-}

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/EntityProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/EntityProperties.cs
@@ -2,4 +2,5 @@ namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 
 /// <summary>Base type for cached Service Bus entity properties.</summary>
 /// <param name="Name">The entity name.</param>
-public abstract record EntityProperties(string Name);
+/// <param name="RequiresSession">Indicates whether the entity requires a session (guarantee the FIFO order).</param>
+public abstract record EntityProperties(string Name, bool RequiresSession);

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/QueueEntityProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/QueueEntityProperties.cs
@@ -1,6 +1,7 @@
 namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <summary>Describes a cached Service Bus queue.</summary>
 /// <param name="Name">The queue name.</param>
+/// <param name="RequiresSession">Indicates whether the queue requires a session (guarantee the FIFO order).</param>
 /// <param name="LockDuration">The lock duration.</param>
 /// <param name="MaxDeliveryCount">The maximum delivery count.</param>
 /// <param name="DefaultMessageTimeToLive">The default message TTL.</param>
@@ -8,11 +9,11 @@ namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <param name="DuplicateDetectionHistoryTimeWindow">The duplicate detection window.</param>
 /// <param name="DeadLetteringOnMessageExpiration">Whether expired messages are dead-lettered.</param>
 /// <param name="EnableBatchedOperations">Whether batched operations are enabled.</param>
-/// <param name="RequiresSession">Whether sessions are required.</param>
 /// <param name="EnablePartitioning">Whether partitioning is enabled.</param>
 /// <param name="AutoDeleteOnIdle">The auto-delete timeout.</param>
 public sealed record QueueEntityProperties(
 	string Name,
+	bool RequiresSession,
 	TimeSpan LockDuration,
 	int MaxDeliveryCount,
 	TimeSpan DefaultMessageTimeToLive,
@@ -20,6 +21,5 @@ public sealed record QueueEntityProperties(
 	TimeSpan DuplicateDetectionHistoryTimeWindow,
 	bool DeadLetteringOnMessageExpiration,
 	bool EnableBatchedOperations,
-	bool RequiresSession,
 	bool EnablePartitioning,
-	TimeSpan AutoDeleteOnIdle) : EntityProperties(Name);
+	TimeSpan AutoDeleteOnIdle) : EntityProperties(Name, RequiresSession);

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/SubscriptionEntityProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/SubscriptionEntityProperties.cs
@@ -2,22 +2,22 @@ namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <summary>Describes a cached Service Bus subscription.</summary>
 /// <param name="Name">The subscription name.</param>
 /// <param name="TopicName">The parent topic name.</param>
+/// <param name="RequiresSession">Indicates whether the subscription requires a session (guarantee the FIFO order).</param>
 /// <param name="LockDuration">The lock duration.</param>
 /// <param name="MaxDeliveryCount">The maximum delivery count.</param>
 /// <param name="DefaultMessageTimeToLive">The default message TTL.</param>
 /// <param name="DeadLetteringOnMessageExpiration">Whether expired messages are dead-lettered.</param>
-/// <param name="RequiresSession">Whether sessions are required.</param>
 /// <param name="EnableBatchedOperations">Whether batched operations are enabled.</param>
 /// <param name="AutoDeleteOnIdle">The auto-delete timeout.</param>
 /// <param name="Rules">The subscription rules.</param>
 public sealed record SubscriptionEntityProperties(
 	string Name,
 	string TopicName,
+	bool RequiresSession,
 	TimeSpan LockDuration,
 	int MaxDeliveryCount,
 	TimeSpan DefaultMessageTimeToLive,
 	bool DeadLetteringOnMessageExpiration,
-	bool RequiresSession,
 	bool EnableBatchedOperations,
 	TimeSpan AutoDeleteOnIdle,
-	IReadOnlyList<SubscriptionFilterRule> Rules) : EntityProperties(Name);
+	IReadOnlyList<SubscriptionFilterRule> Rules) : EntityProperties(Name, RequiresSession);

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/TopicEntityProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/TopicEntityProperties.cs
@@ -15,4 +15,4 @@ public sealed record TopicEntityProperties(
 	TimeSpan DuplicateDetectionHistoryTimeWindow,
 	bool EnableBatchedOperations,
 	bool EnablePartitioning,
-	TimeSpan AutoDeleteOnIdle) : EntityProperties(Name);
+	TimeSpan AutoDeleteOnIdle) : EntityProperties(Name, RequiresSession: false);

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ViewerState.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ViewerState.cs
@@ -1,7 +1,6 @@
 namespace ServiceBusViewer.Business.Viewer.Contracts;
 
 using ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
-using ServiceBusViewer.Business.Viewer.Dependencies;
 
 /// <summary>Represents the current state of the Service Bus viewer.</summary>
 /// <param name="ServiceBusHostName">The host name of the connected Service Bus namespace or emulator.</param>
@@ -27,41 +26,3 @@ public sealed record ViewerState(
 	ReceivedMessage? DisplayedMessage,
 	string? SendResultMessage,
 	string? ReceiveSessionId);
-
-
-/// <summary>Provides extension methods related to <see cref="ViewerState"/>.</summary>
-public static class ViewerStateExtensions
-{
-	/// <summary>Converts the current viewer session state and service bus connection into a <see cref="ViewerState"/> instance.</summary>
-	/// <param name="session">The current viewer session state.</param>
-	/// <param name="connection">The service bus connection.</param>
-	/// <returns>A <see cref="ViewerState"/> instance representing the current state.</returns>
-	public static ViewerState ToViewerState(this IViewerSessionState session, IServiceBusConnection connection)
-	{
-		EntityProperties? selectedEntity = session.SelectedEntityId is null
-			? null
-			: connection.GetEntityProperties(session.SelectedEntityId);
-
-		bool requiresSession = RequiresSession(selectedEntity);
-
-		return new ViewerState(
-			connection.NamespaceHost,
-			selectedEntity?.Name,
-			(selectedEntity as SubscriptionEntityProperties)?.TopicName,
-			requiresSession,
-			connection.IsManagementApiAvailable,
-			[.. connection.AvailableEntities.Select(x => x.ToEntityId())],
-			session.CurrentMessages.Messages,
-			session.CurrentMessages.HasMore,
-			session.DisplayedMessage,
-			session.SendResultMessage,
-			requiresSession ? session.ReceiveSessionId : null);
-	}
-
-	private static bool RequiresSession(EntityProperties? entity)
-		=> entity switch {
-			QueueEntityProperties queue => queue.RequiresSession,
-			SubscriptionEntityProperties subscription => subscription.RequiresSession,
-			_ => false
-		};
-}

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerConnectionService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerConnectionService.cs
@@ -12,7 +12,7 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 		await session.Gate.WaitAsync(cancellationToken);
 
 		try {
-			return session.ToViewerConnectionSnapshot();
+			return ToViewerConnectionSnapshot(session);
 		}
 		finally {
 			session.Gate.Release();
@@ -66,7 +66,7 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 
 		try {
 			await session.ResetConnectionAsync();
-			return session.ToViewerConnectionSnapshot();
+			return ToViewerConnectionSnapshot(session);
 		}
 		finally {
 			session.Gate.Release();
@@ -92,22 +92,25 @@ internal sealed class ViewerConnectionService(IServiceBusConnectionFactory conne
 		if (string.IsNullOrWhiteSpace(settings.QueueOrTopicName))
 			return null;
 
-		EntityProperties? selectedEntity;
-
-		if (!string.IsNullOrWhiteSpace(settings.SubscriptionName)) {
-			selectedEntity = availableEntities.OfType<SubscriptionEntityProperties>()
+		EntityProperties? selectedEntity = string.IsNullOrWhiteSpace(settings.SubscriptionName)
+			? availableEntities.FirstOrDefault(entity =>
+				entity is QueueEntityProperties or TopicEntityProperties
+				&& entity.Name.Equals(settings.QueueOrTopicName, StringComparison.OrdinalIgnoreCase))
+			: availableEntities.OfType<SubscriptionEntityProperties>()
 				.FirstOrDefault(subscription =>
 					subscription.Name.Equals(settings.SubscriptionName, StringComparison.OrdinalIgnoreCase)
 					&& subscription.TopicName.Equals(settings.QueueOrTopicName, StringComparison.OrdinalIgnoreCase));
-		}
-		else {
-			selectedEntity = availableEntities.FirstOrDefault(entity =>
-				entity is QueueEntityProperties or TopicEntityProperties
-				&& entity.Name.Equals(settings.QueueOrTopicName, StringComparison.OrdinalIgnoreCase));
-		}
 
 		return selectedEntity is not null
 			? selectedEntity.ToEntityId()
 			: throw new ArgumentException("The requested queue, topic, or subscription was not found in the connected Service Bus namespace.");
 	}
+
+	private static ViewerConnectionSnapshot ToViewerConnectionSnapshot(IViewerSessionState session)
+		=> new ViewerConnectionSnapshot(
+			session.ConnectionSettings,
+			session.IsConnected
+				? session.ToViewerState(session.Connection!)
+				: null,
+			session.IsConnected);
 }

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -25,9 +25,7 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 				? ReceivedMessageList.Empty
 				: await connection.PeekMessagesAsync(entityId, 50, operationCancellationToken);
 
-			bool requiresSession = entityId is not null
-				&& connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
-					or SubscriptionEntityProperties { RequiresSession: true };
+			bool requiresSession = entityId is not null && connection.GetEntityProperties(entityId).RequiresSession;
 
 			if (!requiresSession)
 				session.ReceiveSessionId = null;
@@ -48,9 +46,10 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 			using var operationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, session.ConnectionCancellationToken);
 			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
+
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
-			bool requiresSession = connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
-				or SubscriptionEntityProperties { RequiresSession: true };
+
+			bool requiresSession = connection.GetEntityProperties(entityId).RequiresSession;
 
 			session.ReceiveSessionId = requiresSession ? sessionId : null;
 			session.DisplayedMessage = await connection.ReceiveMessageAsync(entityId, requiresSession ? sessionId : null, operationCancellationToken);
@@ -85,8 +84,7 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
-			bool requiresSession = connection.GetEntityProperties(entityId) is QueueEntityProperties { RequiresSession: true }
-				or SubscriptionEntityProperties { RequiresSession: true };
+			bool requiresSession = connection.GetEntityProperties(entityId).RequiresSession;
 
 			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
 

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerStateMapper.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerStateMapper.cs
@@ -1,0 +1,31 @@
+namespace ServiceBusViewer.Business.Viewer.Services;
+
+using ServiceBusViewer.Business.Viewer.Contracts;
+using ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
+using ServiceBusViewer.Business.Viewer.Dependencies;
+
+internal static class ViewerStateMapper
+{
+	internal static ViewerState ToViewerState(this IViewerSessionState session, IServiceBusConnection connection)
+	{
+		EntityProperties? selectedEntity = session.SelectedEntityId is not null
+			? connection.GetEntityProperties(session.SelectedEntityId)
+			: null;
+
+		bool requiresSession = selectedEntity?.RequiresSession ?? false;
+
+		return new ViewerState(
+			connection.NamespaceHost,
+			selectedEntity?.Name,
+			(selectedEntity as SubscriptionEntityProperties)?.TopicName,
+			requiresSession,
+			connection.IsManagementApiAvailable,
+			[.. connection.AvailableEntities.Select(x => x.ToEntityId())],
+			session.CurrentMessages.Messages,
+			session.CurrentMessages.HasMore,
+			session.DisplayedMessage,
+			session.SendResultMessage,
+			requiresSession ? session.ReceiveSessionId : null);
+	}
+
+}

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -39,7 +39,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	public EntityProperties GetEntityProperties(EntityId entityId)
 	{
-		ThrowIfDisposed();
+		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		EntityProperties? properties = FindEntity(entityId);
 
@@ -49,7 +49,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	public async Task<ReceivedMessageList> PeekMessagesAsync(EntityId entityId, int maxMessages, CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
+		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		EntityProperties entity = GetEntityProperties(entityId);
 
@@ -65,14 +65,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	public async Task<ReceivedMessage?> ReceiveMessageAsync(EntityId entityId, string? sessionId, CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
+		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		EntityProperties entity = GetEntityProperties(entityId);
-		bool requiresSession = entity switch {
-			QueueEntityProperties queue => queue.RequiresSession,
-			SubscriptionEntityProperties subscription => subscription.RequiresSession,
-			_ => false
-		};
+		bool requiresSession = entity.RequiresSession;
 
 		if (!requiresSession) {
 			await using ServiceBusReceiver nonSessionReceiver = GetReceiver(entity);
@@ -97,7 +93,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	public async Task SendMessageAsync(EntityId entityId, SendCommand command, CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
+		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		EntityProperties entity = GetEntityProperties(entityId);
 		await using ServiceBusSender sender = GetSender(entity);
@@ -134,7 +130,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	public async Task RefreshEntitiesAsync(CancellationToken cancellationToken)
 	{
-		ThrowIfDisposed();
+		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		if (_adminClient is null)
 			throw new InvalidOperationException("Entity list refresh is only available when management access is available.");
@@ -144,16 +140,9 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 		await foreach (QueueProperties queue in _adminClient.GetQueuesAsync(cancellationToken)) {
 			_availableEntities.Add(new QueueEntityProperties(
 				queue.Name,
-				queue.LockDuration,
-				queue.MaxDeliveryCount,
-				queue.DefaultMessageTimeToLive,
-				queue.RequiresDuplicateDetection,
-				queue.DuplicateDetectionHistoryTimeWindow,
-				queue.DeadLetteringOnMessageExpiration,
-				queue.EnableBatchedOperations,
 				queue.RequiresSession,
-				queue.EnablePartitioning,
-				queue.AutoDeleteOnIdle));
+				queue.LockDuration,
+				queue.MaxDeliveryCount, queue.DefaultMessageTimeToLive, queue.RequiresDuplicateDetection, queue.DuplicateDetectionHistoryTimeWindow, queue.DeadLetteringOnMessageExpiration, queue.EnableBatchedOperations, queue.EnablePartitioning, queue.AutoDeleteOnIdle));
 		}
 
 		await foreach (TopicProperties topic in _adminClient.GetTopicsAsync(cancellationToken)) {
@@ -176,14 +165,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				_availableEntities.Add(new SubscriptionEntityProperties(
 					subscription.SubscriptionName,
 					subscription.TopicName,
+					subscription.RequiresSession,
 					subscription.LockDuration,
 					subscription.MaxDeliveryCount,
-					subscription.DefaultMessageTimeToLive,
-					subscription.DeadLetteringOnMessageExpiration,
-					subscription.RequiresSession,
-					subscription.EnableBatchedOperations,
-					subscription.AutoDeleteOnIdle,
-					rules));
+					subscription.DefaultMessageTimeToLive, subscription.DeadLetteringOnMessageExpiration, subscription.EnableBatchedOperations, subscription.AutoDeleteOnIdle, rules));
 			}
 		}
 	}
@@ -199,63 +184,38 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 	}
 
 	private ServiceBusReceiver GetReceiver(EntityProperties entity)
-	{
-		if (entity is SubscriptionEntityProperties subscription) {
-			return _client.CreateReceiver(subscription.TopicName, subscription.Name, new ServiceBusReceiverOptions {
-				ReceiveMode = ServiceBusReceiveMode.PeekLock
-			});
-		}
-
-		if (entity is QueueEntityProperties queue) {
-			return _client.CreateReceiver(queue.Name, new ServiceBusReceiverOptions {
-				ReceiveMode = ServiceBusReceiveMode.PeekLock
-			});
-		}
-
-		throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.");
-	}
+		=> entity switch {
+			SubscriptionEntityProperties subscription => _client.CreateReceiver(subscription.TopicName, subscription.Name, new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.PeekLock }),
+			QueueEntityProperties queue => _client.CreateReceiver(queue.Name, new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.PeekLock }),
+			_ => throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.")
+		};
 
 	private async Task<ServiceBusSessionReceiver> GetSessionReceiverAsync(EntityProperties entity, string? sessionId, CancellationToken cancellationToken)
-	{
-		if (entity is SubscriptionEntityProperties subscription) {
-			return string.IsNullOrWhiteSpace(sessionId)
+		=> entity switch {
+			SubscriptionEntityProperties subscription => string.IsNullOrWhiteSpace(sessionId)
 				? await _client.AcceptNextSessionAsync(subscription.TopicName, subscription.Name, cancellationToken: cancellationToken)
-				: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId, cancellationToken: cancellationToken);
-		}
-
-		if (entity is QueueEntityProperties queue) {
-			return string.IsNullOrWhiteSpace(sessionId)
+				: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId, cancellationToken: cancellationToken),
+			QueueEntityProperties queue => string.IsNullOrWhiteSpace(sessionId)
 				? await _client.AcceptNextSessionAsync(queue.Name, cancellationToken: cancellationToken)
-				: await _client.AcceptSessionAsync(queue.Name, sessionId, cancellationToken: cancellationToken);
-		}
-
-		throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.");
-	}
+				: await _client.AcceptSessionAsync(queue.Name, sessionId, cancellationToken: cancellationToken),
+			_ => throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.")
+		};
 
 	private ServiceBusSender GetSender(EntityProperties entity)
-	{
-		return entity switch {
+		=> entity switch {
 			QueueEntityProperties queue => _client.CreateSender(queue.Name),
 			SubscriptionEntityProperties subscription => _client.CreateSender(subscription.TopicName),
 			TopicEntityProperties topic => _client.CreateSender(topic.Name),
 			_ => throw new InvalidOperationException($"Cannot create sender for entity type '{entity.GetType().Name}'.")
 		};
-	}
 
 	private EntityProperties? FindEntity(EntityId entityId)
-	{
-		return entityId switch {
+		=> entityId switch {
 			QueueEntityId queueId => _availableEntities.FirstOrDefault(p => p is QueueEntityProperties && p.Name == queueId.Name),
 			TopicEntityId topicId => _availableEntities.FirstOrDefault(p => p is TopicEntityProperties && p.Name == topicId.Name),
 			SubscriptionEntityId subscriptionId => _availableEntities.FirstOrDefault(p => p is SubscriptionEntityProperties subscription && subscription.Name == subscriptionId.Name && subscription.TopicName == subscriptionId.TopicName),
 			_ => throw new ArgumentException($"Unknown entity type: {entityId.GetType().FullName}", nameof(entityId))
 		};
-	}
-
-	private void ThrowIfDisposed()
-	{
-		ObjectDisposedException.ThrowIf(_disposed, this);
-	}
 
 	private static ReceivedMessage ConvertToReceivedMessage(ServiceBusReceivedMessage message)
 	{
@@ -312,39 +272,45 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 
 	private static SubscriptionFilterRule ConvertToSubscriptionRule(RuleProperties rule)
 	{
-		if (rule.Filter is SqlRuleFilter sqlFilter) {
-			string? actionExpression = rule.Action is SqlRuleAction sqlAction
+		return rule.Filter switch {
+			SqlRuleFilter sqlFilter => ConvertSqlRule(rule, sqlFilter),
+			CorrelationRuleFilter correlationFilter => ConvertCorrelationRule(rule, correlationFilter),
+			_ => ConvertUnknownRule(rule)
+		};
+
+		static SqlSubscriptionFilterRule ConvertSqlRule(RuleProperties source, SqlRuleFilter filter)
+		{
+			string? actionExpression = source.Action is SqlRuleAction sqlAction
 				? sqlAction.SqlExpression
 				: null;
 
-			return new SqlSubscriptionFilterRule(rule.Name, sqlFilter.SqlExpression, actionExpression);
+			return new SqlSubscriptionFilterRule(source.Name, filter.SqlExpression, actionExpression);
 		}
 
-		if (rule.Filter is CorrelationRuleFilter correlationFilter) {
-			string? actionExpression = rule.Action is SqlRuleAction sqlAction
+		static CorrelationSubscriptionFilterRule ConvertCorrelationRule(RuleProperties source, CorrelationRuleFilter filter)
+		{
+			string? actionExpression = source.Action is SqlRuleAction sqlAction
 				? sqlAction.SqlExpression
 				: null;
 
-			IReadOnlyDictionary<string, object> applicationProperties = correlationFilter.ApplicationProperties
+			IReadOnlyDictionary<string, object> applicationProperties = filter.ApplicationProperties
 				.ToDictionary(static pair => pair.Key, static pair => pair.Value);
 
 			return new CorrelationSubscriptionFilterRule(
-				rule.Name,
-				correlationFilter.CorrelationId,
-				correlationFilter.MessageId,
-				correlationFilter.To,
-				correlationFilter.ReplyTo,
-				correlationFilter.Subject,
-				correlationFilter.SessionId,
-				correlationFilter.ReplyToSessionId,
-				correlationFilter.ContentType,
+				source.Name,
+				filter.CorrelationId,
+				filter.MessageId,
+				filter.To,
+				filter.ReplyTo,
+				filter.Subject,
+				filter.SessionId,
+				filter.ReplyToSessionId,
+				filter.ContentType,
 				applicationProperties,
 				actionExpression);
 		}
 
-		return new UnknownSubscriptionFilterRule(
-			rule.Name,
-			rule.Filter?.GetType().Name ?? "null",
-			"Unknown filter type");
+		static UnknownSubscriptionFilterRule ConvertUnknownRule(RuleProperties source)
+			=> new UnknownSubscriptionFilterRule(source.Name, source.Filter?.GetType().Name ?? "null", "Unknown filter type");
 	}
 }

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnectionFactory.cs
@@ -76,22 +76,22 @@ internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 				false,
 				TimeSpan.MaxValue));
 
-			SubscriptionEntityProperties subscription = new(
+			availableEntities.Add(new SubscriptionEntityProperties(
 				settings.SubscriptionName,
 				settings.QueueOrTopicName,
+				false,
 				TimeSpan.FromMinutes(1),
 				10,
 				TimeSpan.MaxValue,
 				false,
-				false,
 				true,
 				TimeSpan.MaxValue,
-				[]);
-			availableEntities.Add(subscription);
+				[]));
 		}
 		else {
-			QueueEntityProperties queue = new(
+			availableEntities.Add(new QueueEntityProperties(
 				settings.QueueOrTopicName,
+				false,
 				TimeSpan.FromMinutes(1),
 				10,
 				TimeSpan.MaxValue,
@@ -100,9 +100,7 @@ internal sealed class ServiceBusConnectionFactory : IServiceBusConnectionFactory
 				false,
 				true,
 				false,
-				false,
-				TimeSpan.MaxValue);
-			availableEntities.Add(queue);
+				TimeSpan.MaxValue));
 		}
 
 		return new ServiceBusConnection(


### PR DESCRIPTION
This pull request refactors how session requirements are handled for Service Bus entities and improves code organization and clarity. The main focus is on centralizing the `RequiresSession` property in the base `EntityProperties` record, simplifying related logic throughout the codebase, and moving mapping logic to dedicated classes. Additionally, it replaces some extension methods with static methods for better maintainability.

**Entity session handling and type changes:**

* The `EntityProperties` base record now includes a `RequiresSession` property, and all derived entity records (`QueueEntityProperties`, `SubscriptionEntityProperties`, `TopicEntityProperties`) are updated to use this unified approach. This removes the need for type-specific session checks and centralizes session logic. [[1]](diffhunk://#diff-a70806dcbdf6de2c74e3a15a46297b53f85fc694a4e9c59d1cc4b24bb8577687L5-R6) [[2]](diffhunk://#diff-6371d3822cc8188a71b446da4d33244cbedb66fd5a3ff7faa9d992a028bdb1d4R4-R25) [[3]](diffhunk://#diff-8087eb14e061f2dd28c263761a593fce8697196a368793b5618d50f180e754fbR5-R23) [[4]](diffhunk://#diff-2301cf230b7abe6b473077511ef6b53ea5f60098f11f3b1338f16aab7e439228L18-R18)
* All logic throughout the codebase that previously checked for session requirements via type checks is updated to use the new `RequiresSession` property directly, simplifying and clarifying the code. [[1]](diffhunk://#diff-d19c8886a4b2216f13dcf244ef5b152bd4d6d776ef25f6c198f0d98997579bc4L28-R28) [[2]](diffhunk://#diff-d19c8886a4b2216f13dcf244ef5b152bd4d6d776ef25f6c198f0d98997579bc4R49-R52) [[3]](diffhunk://#diff-d19c8886a4b2216f13dcf244ef5b152bd4d6d776ef25f6c198f0d98997579bc4L88-R87) [[4]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L68-R71)

**Refactoring and code organization:**

* The `ViewerState` mapping logic is moved from extension methods in `ViewerState.cs` to a new internal static class `ViewerStateMapper` in its own file, improving separation of concerns and maintainability. [[1]](diffhunk://#diff-dba437fcb9f1ef6ddd61e867924196320165f2a92c97a48c8b6740d9cd595dfbL30-L67) [[2]](diffhunk://#diff-ebefb9f544df05ed99131bed9c22a4952d26d521bd829c145146bc80e3624adeR1-R31)
* Extension methods for converting session state to `ViewerConnectionSnapshot` are removed and replaced with static methods, further clarifying responsibilities and reducing reliance on extension methods. [[1]](diffhunk://#diff-b01041e9ef0abb47682f0c275540542f7e74630fb0c14838d2f2dbc5f641a5e9L42-L59) [[2]](diffhunk://#diff-b00a7dbbf0ff621698f1ae483e9362195629423b8a93e2e14a7cf90acbb55975L15-R15) [[3]](diffhunk://#diff-b00a7dbbf0ff621698f1ae483e9362195629423b8a93e2e14a7cf90acbb55975L69-R69) [[4]](diffhunk://#diff-b00a7dbbf0ff621698f1ae483e9362195629423b8a93e2e14a7cf90acbb55975L95-R115)

**Infrastructure and consistency improvements:**

* The `ServiceBusConnection` methods now consistently use `ObjectDisposedException.ThrowIf` for disposal checks instead of a custom `ThrowIfDisposed` method, standardizing resource management. [[1]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L42-R42) [[2]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L52-R52) [[3]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L68-R71) [[4]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L100-R96) [[5]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L137-R133)
* Construction of entity property objects in `RefreshEntitiesAsync` is updated to match the new constructors and property order, ensuring correct instantiation and session handling. [[1]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L147-R145) [[2]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9R168-R171)