### PR TITLE
fix: preserve the last received message after send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Service Bus Viewer Version History
 
-## 0.40.3 (2026-08-13)
+## 0.40.4 (2026-08-16)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Sending a message no longer clears the last received message details.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.40.3 (2026-08-13)
+## 0.40.4 (2026-08-16)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Sending a message no longer clears the last received message details.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -185,7 +185,6 @@ export function ViewerPage() {
 			if (currentViewer) {
 				setViewerState({
 					...currentViewer,
-					displayedMessage: null,
 					sendResultMessage: buildSendResultMessage(request),
 				});
 			}
@@ -353,7 +352,7 @@ export function ViewerPage() {
 							<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
 								<div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/40">
 									<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-										Received Message
+										Last Received Message
 									</h2>
 									{currentViewer?.displayedMessage ? (
 										<span className="rounded-xl bg-slate-200 px-2 py-1 font-mono text-[11px] text-slate-600 dark:bg-slate-800 dark:text-slate-300">

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -88,7 +88,6 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 
 			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
 
-			session.DisplayedMessage = null;
 			session.SendResultMessage = BuildSendResultMessage(command.MessageProperties.ContentType, command.MessageProperties.MessageId);
 
 			if (!requiresSession)

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.3</Version>
+		<Version>0.40.4</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
+++ b/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
@@ -34,7 +34,7 @@ await builder.Build().RunAsync();
 The integration exposes Service Bus Viewer on container port `8080`. You can pin a host port and override the image tag during registration:
 
 ```csharp
-builder.AddServiceBusViewer("servicebusviewer", tag: "0.40.3", httpPort: 8081);
+builder.AddServiceBusViewer("servicebusviewer", tag: "0.40.4", httpPort: 8081);
 ```
 
 ### Configure connection settings with `WithConnectionSettings(...)`


### PR DESCRIPTION
- keep the last received message visible after sending a new message
- rename "Received Message" to "Last Received Message" in the viewer