### PR TITLE
Version 0.40.5

### DIFF
--- a/.agents/specs/PROJECT_DECISIONS.md
+++ b/.agents/specs/PROJECT_DECISIONS.md
@@ -1,5 +1,10 @@
 # Project Decisions
 
+## 2026-08-16: Empty receive timeout behavior
+
+- Receive operations treat an empty queue or subscription as a short-poll scenario and return after about one second instead of inheriting the Azure Service Bus default wait timeout.
+- Session-enabled receives apply the same bounded wait to session acquisition and normalize the expected "no active session/message available" timeout into the same empty-receive result used for non-session entities.
+
 ## 2026-08-13: Aspire hosting package defaults
 
 - The reusable `SolidCode.Aspire.Hosting.ServiceBusViewer` package registers the published `ghcr.io/veselovandrey/servicebusviewer:latest` container image by default and exposes convenience helpers for the supported `SERVICEBUSVIEWER_*` runtime environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Service Bus Viewer Version History
 
-## 0.40.4 (2026-08-16)
+## 0.40.5 (2026-08-17)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
 - **Fixed:** Sending a message no longer clears the last received message details.
+- **Fixed:** Empty receives from queues and subscriptions now return after about one second instead of waiting for the Azure Service Bus default timeout, including session-enabled entities with no active messages.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Service Bus Viewer Version History
 
-## 0.40.3 (2026-08-13)
+## 0.40.4 (2026-08-16)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Sending a message no longer clears the last received message details.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.40.4 (2026-08-16)
+## 0.40.5 (2026-08-17)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
 - **Fixed:** Sending a message no longer clears the last received message details.
+- **Fixed:** Empty receives from queues and subscriptions now return after about one second instead of waiting for the Azure Service Bus default timeout, including session-enabled entities with no active messages.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.40.3 (2026-08-13)
+## 0.40.4 (2026-08-16)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.
 - **Changed:** Reduced the combined Docker image size by using the .NET 10 Ubuntu Chiseled composite runtime with globalization support.
+- **Fixed:** Sending a message no longer clears the last received message details.
 - **Fixed:** Aborted requests and disconnects now cancel in-flight Service Bus operations so they do not block the browser session.
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.

--- a/src/ServiceBusViewer.Web/src/components/common/Alert.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/Alert.tsx
@@ -16,7 +16,7 @@ const toneClasses = {
 const iconMarkup = {
   error: (
     <svg
-      className="mt-0.5 h-5 w-5 shrink-0"
+      className="h-5 w-5 shrink-0"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -29,7 +29,7 @@ const iconMarkup = {
   ),
   success: (
     <svg
-      className="mt-0.5 h-5 w-5 shrink-0"
+      className="h-5 w-5 shrink-0"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -51,9 +51,11 @@ export function Alert({ className, messages, tone }: AlertProps) {
     return null;
   }
 
+  const layoutClassName = messages.length === 1 ? 'items-center' : 'items-start';
+
   return (
     <div className={cx('rounded-2xl border px-4 py-3 text-sm', toneClasses[tone], className)}>
-      <div className="flex items-start gap-3">
+      <div className={cx('flex gap-3', layoutClassName)}>
         {iconMarkup[tone]}
         <div className="space-y-1">
           {messages.map((message, index) => (

--- a/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
+++ b/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
@@ -1,471 +1,481 @@
 import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type FormEvent,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ChangeEvent,
+	type FormEvent,
 } from 'react';
 import { useStoredBoolean } from '../../hooks/useStoredBoolean';
 import { cx } from '../../lib/cx';
 import type {
-  ApplicationPropertyInputDto,
-  ApplicationPropertyType,
-  SendMessagePropertiesDto,
-  SendMessageRequestDto,
+	ApplicationPropertyInputDto,
+	ApplicationPropertyType,
+	SendMessagePropertiesDto,
+	SendMessageRequestDto,
 } from '../../types/serviceBus';
 
 const commonContentTypes = [
-  'application/json',
-  'text/plain',
-  'text/html',
-  'application/xml',
-  'text/xml',
-  'application/x-www-form-urlencoded',
-  'text/csv',
+	'application/json',
+	'text/plain',
+	'text/html',
+	'application/xml',
+	'text/xml',
+	'application/x-www-form-urlencoded',
+	'text/csv',
 ] as const;
 
 const applicationPropertyTypes = [
-  'String',
-  'Bool',
-  'Byte',
-  'SByte',
-  'Short',
-  'UShort',
-  'Int',
-  'UInt',
-  'Long',
-  'ULong',
-  'Float',
-  'Double',
-  'Decimal',
-  'Char',
-  'Guid',
-  'DateTime',
-  'DateTimeOffset',
-  'TimeSpan',
+	'String',
+	'Bool',
+	'Byte',
+	'SByte',
+	'Short',
+	'UShort',
+	'Int',
+	'UInt',
+	'Long',
+	'ULong',
+	'Float',
+	'Double',
+	'Decimal',
+	'Char',
+	'Guid',
+	'DateTime',
+	'DateTimeOffset',
+	'TimeSpan',
 ] as const satisfies readonly ApplicationPropertyType[];
 
 interface SendMessageFormProps {
-  canSend: boolean;
-  isSubmitting: boolean;
-  onSubmit: (request: SendMessageRequestDto) => Promise<void>;
-  onValidationError: (messages: string[]) => void;
+	canSend: boolean;
+	isSubmitting: boolean;
+	requiresSession: boolean;
+	onSubmit: (request: SendMessageRequestDto) => Promise<void>;
+	onValidationError: (messages: string[]) => void;
 }
 
 const emptyProperties: SendMessagePropertiesDto = {
-  contentType: '',
-  correlationId: '',
-  messageId: '',
-  scheduledEnqueueTime: null,
-  sessionId: '',
-  timeToLive: '',
+	contentType: '',
+	correlationId: '',
+	messageId: '',
+	scheduledEnqueueTime: null,
+	sessionId: '',
+	timeToLive: '',
 };
 
 function createProperty(): ApplicationPropertyInputDto {
-  return { key: '', type: 'String', value: '' };
+	return { key: '', type: 'String', value: '' };
 }
 
 export function SendMessageForm({
-  canSend,
-  isSubmitting,
-  onSubmit,
-  onValidationError,
+	canSend,
+	isSubmitting,
+	requiresSession,
+	onSubmit,
+	onValidationError,
 }: SendMessageFormProps) {
-  const [isOpen, setIsOpen] = useStoredBoolean('sendFormOpen', true);
-  const [messageBody, setMessageBody] = useState('');
-  const [messageProperties, setMessageProperties] =
-    useState<SendMessagePropertiesDto>(emptyProperties);
-  const [applicationProperties, setApplicationProperties] = useState<
-    ApplicationPropertyInputDto[]
-  >([]);
-  const [isContentTypeMenuOpen, setIsContentTypeMenuOpen] = useState(false);
-  const [contentTypeFilter, setContentTypeFilter] = useState('');
-  const contentTypeContainerRef = useRef<HTMLDivElement | null>(null);
+	const [isOpen, setIsOpen] = useStoredBoolean('sendFormOpen', true);
+	const [messageBody, setMessageBody] = useState('');
+	const [messageProperties, setMessageProperties] =
+		useState<SendMessagePropertiesDto>(emptyProperties);
+	const [applicationProperties, setApplicationProperties] = useState<
+		ApplicationPropertyInputDto[]
+	>([]);
+	const [isContentTypeMenuOpen, setIsContentTypeMenuOpen] = useState(false);
+	const [contentTypeFilter, setContentTypeFilter] = useState('');
+	const contentTypeContainerRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => {
-    if (!isContentTypeMenuOpen) {
-      return;
-    }
+	useEffect(() => {
+		if (!isContentTypeMenuOpen) {
+			return;
+		}
 
-    const handleClick = (event: MouseEvent) => {
-      if (!(event.target instanceof Node)) {
-        return;
-      }
+		const handleClick = (event: MouseEvent) => {
+			if (!(event.target instanceof Node)) {
+				return;
+			}
 
-      if (!contentTypeContainerRef.current?.contains(event.target)) {
-        setIsContentTypeMenuOpen(false);
-      }
-    };
+			if (!contentTypeContainerRef.current?.contains(event.target)) {
+				setIsContentTypeMenuOpen(false);
+			}
+		};
 
-    document.addEventListener('click', handleClick);
-    return () => document.removeEventListener('click', handleClick);
-  }, [isContentTypeMenuOpen]);
+		document.addEventListener('click', handleClick);
+		return () => document.removeEventListener('click', handleClick);
+	}, [isContentTypeMenuOpen]);
 
-  const filteredContentTypes = useMemo(() => {
-    const query = contentTypeFilter.trim().toLowerCase();
-    if (!query) {
-      return [...commonContentTypes];
-    }
+	const filteredContentTypes = useMemo(() => {
+		const query = contentTypeFilter.trim().toLowerCase();
+		if (!query) {
+			return [...commonContentTypes];
+		}
 
-    return commonContentTypes.filter((contentType) =>
-      contentType.toLowerCase().includes(query),
-    );
-  }, [contentTypeFilter]);
+		return commonContentTypes.filter((contentType) =>
+			contentType.toLowerCase().includes(query),
+		);
+	}, [contentTypeFilter]);
 
-  const updateProperty = (
-    index: number,
-    key: keyof ApplicationPropertyInputDto,
-    value: string,
-  ) => {
-    setApplicationProperties((current) =>
-      current.map((property, propertyIndex) =>
-        propertyIndex === index ? { ...property, [key]: value } : property,
-      ),
-    );
-  };
+	const updateProperty = (
+		index: number,
+		key: keyof ApplicationPropertyInputDto,
+		value: string,
+	) => {
+		setApplicationProperties((current) =>
+			current.map((property, propertyIndex) =>
+				propertyIndex === index ? { ...property, [key]: value } : property,
+			),
+		);
+	};
 
-  const validate = (): string[] => {
-    const errors: string[] = [];
-    if (messageBody.trim().length === 0) {
-      errors.push('Message body cannot be empty.');
-    }
+	const validate = (): string[] => {
+		const errors: string[] = [];
+		if (messageBody.trim().length === 0) {
+			errors.push('Message body cannot be empty.');
+		}
 
-    if (messageProperties.messageId.length > 128) {
-      errors.push('The Message ID must be 128 characters or fewer.');
-    }
+		if (messageProperties.messageId.length > 128) {
+			errors.push('The Message ID must be 128 characters or fewer.');
+		}
 
-    if (messageProperties.sessionId.length > 128) {
-      errors.push('The Session ID must be 128 characters or fewer.');
-    }
+		if (messageProperties.sessionId.length > 128) {
+			errors.push('The Session ID must be 128 characters or fewer.');
+		}
 
-    if (messageProperties.correlationId.length > 128) {
-      errors.push('The Correlation ID must be 128 characters or fewer.');
-    }
+		if (requiresSession && messageProperties.sessionId.trim().length === 0) {
+			errors.push('A Session ID is required when sending to a session-enabled queue or topic.');
+		}
 
-    return errors;
-  };
+		if (messageProperties.correlationId.length > 128) {
+			errors.push('The Correlation ID must be 128 characters or fewer.');
+		}
 
-  const resetForm = () => {
-    setMessageBody('');
-    setMessageProperties(emptyProperties);
-    setApplicationProperties([]);
-    setIsContentTypeMenuOpen(false);
-    setContentTypeFilter('');
-  };
+		return errors;
+	};
 
-  const handlePropertiesChange = (
-    key: keyof SendMessagePropertiesDto,
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) => {
-    const value = event.target.value;
-    setMessageProperties((current) => ({
-      ...current,
-      [key]: key === 'scheduledEnqueueTime' ? (value ? value : null) : value,
-    }));
-    if (key === 'contentType') {
-      setContentTypeFilter(value);
-      setIsContentTypeMenuOpen(true);
-    }
-  };
+	const resetForm = () => {
+		setMessageBody('');
+		setMessageProperties(emptyProperties);
+		setApplicationProperties([]);
+		setIsContentTypeMenuOpen(false);
+		setContentTypeFilter('');
+	};
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const errors = validate();
-    if (errors.length > 0) {
-      onValidationError(errors);
-      return;
-    }
+	const handlePropertiesChange = (
+		key: keyof SendMessagePropertiesDto,
+		event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+	) => {
+		const value = event.target.value;
+		setMessageProperties((current) => ({
+			...current,
+			[key]: key === 'scheduledEnqueueTime' ? (value ? value : null) : value,
+		}));
+		if (key === 'contentType') {
+			setContentTypeFilter(value);
+			setIsContentTypeMenuOpen(true);
+		}
+	};
 
-    await onSubmit({
-      sendMessageApplicationProperties: applicationProperties,
-      sendMessageBody: messageBody,
-      sendMessageProperties: {
-        ...messageProperties,
-        scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
-      },
-    });
-    resetForm();
-  };
+	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		const errors = validate();
+		if (errors.length > 0) {
+			onValidationError(errors);
+			return;
+		}
 
-  return (
-    <section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
-      <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
-        <h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-          Send Message
-        </h2>
-        <button
-          type="button"
-          className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
-          onClick={() => setIsOpen((current) => !current)}
-        >
-          <span className="material-icons-round text-sm">
-            {isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-          </span>
-          <span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
-        </button>
-      </div>
+		await onSubmit({
+			sendMessageApplicationProperties: applicationProperties,
+			sendMessageBody: messageBody,
+			sendMessageProperties: {
+				...messageProperties,
+				scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
+			},
+		});
+		resetForm();
+	};
 
-      <div className={cx('send-form-transition', !isOpen && 'js-send-form-hidden')}>
-        <form className="p-4 lg:p-6" onSubmit={(event) => void handleSubmit(event)}>
-          <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_19rem]">
-            <div>
-              <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                Payload
-              </label>
-              <textarea
-                className="block min-h-56 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:placeholder:text-slate-500 dark:focus:border-brand-400"
-                rows={12}
-                value={messageBody}
-                onChange={(event) => setMessageBody(event.target.value)}
-              />
-            </div>
+	return (
+		<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
+			<div className="flex items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
+				<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
+					Send Message
+				</h2>
+				<button
+					type="button"
+					className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
+					onClick={() => setIsOpen((current) => !current)}
+				>
+					<span className="material-icons-round text-sm">
+						{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+					</span>
+					<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
+				</button>
+			</div>
 
-            <div className="space-y-4">
-              <div>
-                <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  Message ID
-                </label>
-                <input
-                  type="text"
-                  maxLength={128}
-                  className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                  value={messageProperties.messageId}
-                  onChange={(event) => handlePropertiesChange('messageId', event)}
-                />
-              </div>
+			<div className={cx('send-form-transition', !isOpen && 'js-send-form-hidden')}>
+				<form className="p-4 lg:p-6" onSubmit={(event) => void handleSubmit(event)}>
+					<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_19rem]">
+						<div>
+							<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+								Payload
+							</label>
+							<textarea
+								className="block min-h-56 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:placeholder:text-slate-500 dark:focus:border-brand-400"
+								rows={12}
+								value={messageBody}
+								onChange={(event) => setMessageBody(event.target.value)}
+							/>
+						</div>
 
-              <div>
-                <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  Session ID
-                </label>
-                <input
-                  type="text"
-                  maxLength={128}
-                  placeholder="Optional"
-                  className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                  value={messageProperties.sessionId}
-                  onChange={(event) => handlePropertiesChange('sessionId', event)}
-                />
-              </div>
+						<div className="space-y-4">
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Message ID
+								</label>
+								<input
+									type="text"
+									maxLength={128}
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.messageId}
+									onChange={(event) => handlePropertiesChange('messageId', event)}
+								/>
+							</div>
 
-              <div>
-                <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  Correlation ID
-                </label>
-                <input
-                  type="text"
-                  maxLength={128}
-                  className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                  value={messageProperties.correlationId}
-                  onChange={(event) => handlePropertiesChange('correlationId', event)}
-                />
-              </div>
+							<div>
+								<label className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									<span>Session ID</span>
+								</label>
+								<input
+									type="text"
+									maxLength={128}
+									required={requiresSession}
+									aria-required={requiresSession}
+									placeholder={
+										requiresSession ? 'Required for session-enabled entities' : 'Optional'
+									}
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.sessionId}
+									onChange={(event) => handlePropertiesChange('sessionId', event)}
+								/>
+							</div>
 
-              <div>
-                <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  Content Type
-                </label>
-                <div className="relative" ref={contentTypeContainerRef}>
-                  <div className="flex items-stretch overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 transition focus-within:border-brand-500 focus-within:ring-2 focus-within:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:shadow-black/20 dark:focus-within:border-brand-400">
-                    <input
-                      type="text"
-                      autoComplete="off"
-                      className="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-sm text-slate-700 focus:ring-0 dark:text-slate-100"
-                      value={messageProperties.contentType}
-                      onChange={(event) => handlePropertiesChange('contentType', event)}
-                      onFocus={() => setIsContentTypeMenuOpen(true)}
-                      onKeyDown={(event) => {
-                        if (event.key === 'Escape') {
-                          setIsContentTypeMenuOpen(false);
-                        }
-                      }}
-                    />
-                    <button
-                      type="button"
-                      className="inline-flex w-11 items-center justify-center border-l border-slate-200 bg-slate-50 text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
-                      aria-expanded={isContentTypeMenuOpen}
-                      aria-controls="contentTypePickerMenu"
-                      aria-label="Toggle common content types"
-                      title="Toggle common content types"
-                      onClick={() => setIsContentTypeMenuOpen((current) => !current)}
-                    >
-                      <svg
-                        className="h-4 w-4"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.8"
-                        aria-hidden="true"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
-                      </svg>
-                    </button>
-                  </div>
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Correlation ID
+								</label>
+								<input
+									type="text"
+									maxLength={128}
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.correlationId}
+									onChange={(event) => handlePropertiesChange('correlationId', event)}
+								/>
+							</div>
 
-                  <div
-                    id="contentTypePickerMenu"
-                    className={cx(
-                      'absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl shadow-slate-200/60 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/30',
-                      !isContentTypeMenuOpen && 'hidden',
-                    )}
-                  >
-                    <div className="border-b border-slate-200 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:border-slate-800 dark:text-slate-400">
-                      Common content types
-                    </div>
-                    <div className="custom-scrollbar h-48 overflow-y-scroll p-2 pr-2" style={{ scrollbarGutter: 'stable' }}>
-                      <div className="grid gap-1.5">
-                        {filteredContentTypes.map((contentType) => (
-                          <button
-                            key={contentType}
-                            type="button"
-                            className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm font-medium text-slate-700 transition hover:bg-brand-50 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-slate-200 dark:hover:bg-brand-950/30 dark:hover:text-brand-300"
-                            onClick={() => {
-                              setMessageProperties((current) => ({ ...current, contentType }));
-                              setContentTypeFilter(contentType);
-                              setIsContentTypeMenuOpen(false);
-                            }}
-                          >
-                            <span>{contentType}</span>
-                          </button>
-                        ))}
-                      </div>
-                      {filteredContentTypes.length === 0 ? (
-                        <div className="px-3 py-4 text-sm text-slate-500 dark:text-slate-400">
-                          No matching content types.
-                        </div>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Content Type
+								</label>
+								<div className="relative" ref={contentTypeContainerRef}>
+									<div className="flex items-stretch overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 transition focus-within:border-brand-500 focus-within:ring-2 focus-within:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:shadow-black/20 dark:focus-within:border-brand-400">
+										<input
+											type="text"
+											autoComplete="off"
+											className="min-w-0 flex-1 border-0 bg-transparent px-3 py-2 text-sm text-slate-700 focus:ring-0 dark:text-slate-100"
+											value={messageProperties.contentType}
+											onChange={(event) => handlePropertiesChange('contentType', event)}
+											onFocus={() => setIsContentTypeMenuOpen(true)}
+											onKeyDown={(event) => {
+												if (event.key === 'Escape') {
+													setIsContentTypeMenuOpen(false);
+												}
+											}}
+										/>
+										<button
+											type="button"
+											className="inline-flex w-11 items-center justify-center border-l border-slate-200 bg-slate-50 text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 focus-visible:outline-none dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white"
+											aria-expanded={isContentTypeMenuOpen}
+											aria-controls="contentTypePickerMenu"
+											aria-label="Toggle common content types"
+											title="Toggle common content types"
+											onClick={() => setIsContentTypeMenuOpen((current) => !current)}
+										>
+											<svg
+												className="h-4 w-4"
+												viewBox="0 0 24 24"
+												fill="none"
+												stroke="currentColor"
+												strokeWidth="1.8"
+												aria-hidden="true"
+											>
+												<path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+											</svg>
+										</button>
+									</div>
 
-          <div className="mt-6 grid gap-4 lg:grid-cols-2">
-            <div>
-              <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                Scheduled Enqueue Time
-              </label>
-              <input
-                type="datetime-local"
-                className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                value={messageProperties.scheduledEnqueueTime ?? ''}
-                onChange={(event) => handlePropertiesChange('scheduledEnqueueTime', event)}
-              />
-            </div>
+									<div
+										id="contentTypePickerMenu"
+										className={cx(
+											'absolute left-0 right-0 top-full z-20 mt-2 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl shadow-slate-200/60 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/30',
+											!isContentTypeMenuOpen && 'hidden',
+										)}
+									>
+										<div className="border-b border-slate-200 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:border-slate-800 dark:text-slate-400">
+											Common content types
+										</div>
+										<div className="custom-scrollbar h-48 overflow-y-scroll p-2 pr-2" style={{ scrollbarGutter: 'stable' }}>
+											<div className="grid gap-1.5">
+												{filteredContentTypes.map((contentType) => (
+													<button
+														key={contentType}
+														type="button"
+														className="flex w-full items-center rounded-lg px-3 py-2 text-left text-sm font-medium text-slate-700 transition hover:bg-brand-50 hover:text-brand-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:text-slate-200 dark:hover:bg-brand-950/30 dark:hover:text-brand-300"
+														onClick={() => {
+															setMessageProperties((current) => ({ ...current, contentType }));
+															setContentTypeFilter(contentType);
+															setIsContentTypeMenuOpen(false);
+														}}
+													>
+														<span>{contentType}</span>
+													</button>
+												))}
+											</div>
+											{filteredContentTypes.length === 0 ? (
+												<div className="px-3 py-4 text-sm text-slate-500 dark:text-slate-400">
+													No matching content types.
+												</div>
+											) : null}
+										</div>
+									</div>
+								</div>
+							</div>
+						</div>
+					</div>
 
-            <div>
-              <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                Time To Live
-              </label>
-              <input
-                type="text"
-                placeholder="hh:mm:ss"
-                className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                value={messageProperties.timeToLive}
-                onChange={(event) => handlePropertiesChange('timeToLive', event)}
-              />
-            </div>
-          </div>
+					<div className="mt-6 grid gap-4 lg:grid-cols-2">
+						<div>
+							<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+								Scheduled Enqueue Time
+							</label>
+							<input
+								type="datetime-local"
+								className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+								value={messageProperties.scheduledEnqueueTime ?? ''}
+								onChange={(event) => handlePropertiesChange('scheduledEnqueueTime', event)}
+							/>
+						</div>
 
-          <div className="mt-6">
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <div>
-                <label className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  Application Properties
-                </label>
-                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                  Optional typed key-value metadata to attach to the outgoing message.
-                </p>
-              </div>
-              <button
-                type="button"
-                className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
-                onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
-              >
-                <svg
-                  className="h-4 w-4"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.8"
-                  aria-hidden="true"
-                >
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
-                </svg>
-                Add Property
-              </button>
-            </div>
+						<div>
+							<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+								Time To Live
+							</label>
+							<input
+								type="text"
+								placeholder="hh:mm:ss"
+								className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+								value={messageProperties.timeToLive}
+								onChange={(event) => handlePropertiesChange('timeToLive', event)}
+							/>
+						</div>
+					</div>
 
-            <div className="space-y-3">
-              {applicationProperties.map((property, index) => (
-                <div
-                  key={`property-${index}`}
-                  className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-950/60 xl:grid-cols-[minmax(0,1fr)_11rem_minmax(0,1fr)_auto]"
-                >
-                  <input
-                    type="text"
-                    placeholder="Key"
-                    className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                    value={property.key}
-                    onChange={(event) => updateProperty(index, 'key', event.target.value)}
-                  />
-                  <select
-                    className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                    value={property.type}
-                    onChange={(event) => updateProperty(index, 'type', event.target.value)}
-                  >
-                    {applicationPropertyTypes.map((type) => (
-                      <option key={type} value={type}>
-                        {type}
-                      </option>
-                    ))}
-                  </select>
-                  <input
-                    type="text"
-                    placeholder="Value"
-                    className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-                    value={property.value}
-                    onChange={(event) => updateProperty(index, 'value', event.target.value)}
-                  />
-                  <button
-                    type="button"
-                    className="inline-flex items-center justify-center rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-300 dark:hover:bg-rose-950/70"
-                    onClick={() =>
-                      setApplicationProperties((current) =>
-                        current.filter((_, propertyIndex) => propertyIndex !== index),
-                      )
-                    }
-                  >
-                    Remove
-                  </button>
-                </div>
-              ))}
-            </div>
-          </div>
+					<div className="mt-6">
+						<div className="mb-3 flex items-center justify-between gap-3">
+							<div>
+								<label className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Application Properties
+								</label>
+								<p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+									Optional typed key-value metadata to attach to the outgoing message.
+								</p>
+							</div>
+							<button
+								type="button"
+								className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+								onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
+							>
+								<svg
+									className="h-4 w-4"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="1.8"
+									aria-hidden="true"
+								>
+									<path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+								</svg>
+								Add Property
+							</button>
+						</div>
 
-          <div className="mt-6 flex justify-end">
-            <button
-              type="submit"
-              className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-950/20 transition hover:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
-              disabled={!canSend || isSubmitting}
-            >
-              <svg
-                className="h-4 w-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.8"
-                aria-hidden="true"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h11M12 5l7 7-7 7" />
-              </svg>
-              {isSubmitting ? 'Sending...' : 'Send Message'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </section>
-  );
+						<div className="space-y-3">
+							{applicationProperties.map((property, index) => (
+								<div
+									key={`property-${index}`}
+									className="grid gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-950/60 xl:grid-cols-[minmax(0,1fr)_11rem_minmax(0,1fr)_auto]"
+								>
+									<input
+										type="text"
+										placeholder="Key"
+										className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+										value={property.key}
+										onChange={(event) => updateProperty(index, 'key', event.target.value)}
+									/>
+									<select
+										className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+										value={property.type}
+										onChange={(event) => updateProperty(index, 'type', event.target.value)}
+									>
+										{applicationPropertyTypes.map((type) => (
+											<option key={type} value={type}>
+												{type}
+											</option>
+										))}
+									</select>
+									<input
+										type="text"
+										placeholder="Value"
+										className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+										value={property.value}
+										onChange={(event) => updateProperty(index, 'value', event.target.value)}
+									/>
+									<button
+										type="button"
+										className="inline-flex items-center justify-center rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 dark:border-rose-900/70 dark:bg-rose-950/40 dark:text-rose-300 dark:hover:bg-rose-950/70"
+										onClick={() =>
+											setApplicationProperties((current) =>
+												current.filter((_, propertyIndex) => propertyIndex !== index),
+											)
+										}
+									>
+										Remove
+									</button>
+								</div>
+							))}
+						</div>
+					</div>
+
+					<div className="mt-6 flex justify-end">
+						<button
+							type="submit"
+							className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-950/20 transition hover:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+							disabled={!canSend || isSubmitting}
+						>
+							<svg
+								className="h-4 w-4"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="1.8"
+								aria-hidden="true"
+							>
+								<path strokeLinecap="round" strokeLinejoin="round" d="M5 12h11M12 5l7 7-7 7" />
+							</svg>
+							{isSubmitting ? 'Sending...' : 'Send Message'}
+						</button>
+					</div>
+				</form>
+			</div>
+		</section>
+	);
 }

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -301,13 +301,18 @@ export function ViewerPage() {
 								<button
 									type="button"
 									className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs shadow-sm transition hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-zinc-800 dark:bg-zinc-900 dark:hover:bg-zinc-800"
+									aria-busy={pendingAction === 'refresh'}
 									disabled={pendingAction === 'refresh'}
 									onClick={() => {
 										void handleRefresh();
 									}}
 								>
-									<span className="material-icons-round text-sm">refresh</span>
-									{pendingAction === 'refresh' ? 'Refreshing...' : 'Refresh'}
+									<span
+										className={`material-icons-round text-sm${pendingAction === 'refresh' ? ' animate-spin' : ''}`}
+									>
+										refresh
+									</span>
+									Refresh
 								</button>
 
 								<div className="inline-flex items-stretch overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-900">
@@ -345,6 +350,7 @@ export function ViewerPage() {
 							<SendMessageForm
 								canSend={Boolean(currentViewer?.entityName)}
 								isSubmitting={pendingAction === 'send'}
+								requiresSession={Boolean(currentViewer?.requiresSession)}
 								onSubmit={handleSend}
 								onValidationError={setErrorMessages}
 							/>

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -185,7 +185,6 @@ export function ViewerPage() {
 			if (currentViewer) {
 				setViewerState({
 					...currentViewer,
-					displayedMessage: null,
 					sendResultMessage: buildSendResultMessage(request),
 				});
 			}
@@ -353,7 +352,7 @@ export function ViewerPage() {
 							<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
 								<div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/40">
 									<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-										Received Message
+										Last Received Message
 									</h2>
 									{currentViewer?.displayedMessage ? (
 										<span className="rounded-xl bg-slate-200 px-2 py-1 font-mono text-[11px] text-slate-600 dark:bg-slate-800 dark:text-slate-300">

--- a/src/ServiceBusViewer/Api/ExceptionHandling/ApiExceptionHandler.cs
+++ b/src/ServiceBusViewer/Api/ExceptionHandling/ApiExceptionHandler.cs
@@ -68,6 +68,7 @@ internal sealed class ApiExceptionHandler(
 		=> exception switch {
 			ViewerAlreadyConnectedException => new ExceptionResponse(StatusCodes.Status409Conflict, "Already connected", exception.Message, false),
 			ViewerNotConnectedException => new ExceptionResponse(StatusCodes.Status409Conflict, "Not connected", exception.Message, false),
+			SendMessageValidationException => new ExceptionResponse(StatusCodes.Status400BadRequest, "Invalid request", exception.Message, false),
 			OperationCanceledException => new ExceptionResponse(StatusCodes.Status409Conflict, "Operation cancelled", "The Service Bus operation was cancelled because the viewer disconnected.", false),
 			ArgumentException or FormatException => new ExceptionResponse(StatusCodes.Status400BadRequest, "Invalid request", exception.Message, false),
 			RequestFailedException or ServiceBusException => new ExceptionResponse(

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/SendMessageValidationException.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/SendMessageValidationException.cs
@@ -1,0 +1,4 @@
+namespace ServiceBusViewer.Business.Viewer.Contracts;
+
+/// <summary>Indicates that the current send request is invalid for the selected Service Bus entity.</summary>
+public sealed class SendMessageValidationException(string message) : Exception(message);

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -84,18 +84,26 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 			CancellationToken operationCancellationToken = operationCancellationSource.Token;
 			IServiceBusConnection connection = session.Connection ?? throw new ViewerNotConnectedException();
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
-			bool requiresSession = connection.GetEntityProperties(entityId).RequiresSession;
+			EntityProperties entity = connection.GetEntityProperties(entityId);
+
+			ValidateRequiredSessionId(entity, command.MessageProperties);
 
 			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
 
 			session.SendResultMessage = BuildSendResultMessage(command.MessageProperties.ContentType, command.MessageProperties.MessageId);
 
-			if (!requiresSession)
+			if (!entity.RequiresSession)
 				session.ReceiveSessionId = null;
 		}
 		finally {
 			session.Gate.Release();
 		}
+	}
+
+	private static void ValidateRequiredSessionId(EntityProperties entity, MessageProperties messageProperties)
+	{
+		if (entity.RequiresSession && string.IsNullOrWhiteSpace(messageProperties.SessionId))
+			throw new SendMessageValidationException($"A Session ID is required when sending to '{entity.Name}' because the selected entity requires sessions.");
 	}
 
 	private static string BuildSendResultMessage(string? sentContentType, string? sentMessageId)

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -88,7 +88,6 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 
 			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
 
-			session.DisplayedMessage = null;
 			session.SendResultMessage = BuildSendResultMessage(command.MessageProperties.ContentType, command.MessageProperties.MessageId);
 
 			if (!requiresSession)

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -10,7 +10,7 @@ using ServiceBusViewer.Business.Viewer.Dependencies;
 /// <summary>Manages a single browser-session-scoped Service Bus connection and entity cache.</summary>
 internal sealed class ServiceBusConnection : IServiceBusConnection
 {
-	private const int _maxMessagesToPeek = 50;
+	private static readonly TimeSpan _emptyReceiveWaitTime = TimeSpan.FromSeconds(1);
 
 	private readonly ServiceBusClient _client;
 	private readonly ServiceBusAdministrationClient? _adminClient;
@@ -68,27 +68,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 		ObjectDisposedException.ThrowIf(_disposed, this);
 
 		EntityProperties entity = GetEntityProperties(entityId);
-		bool requiresSession = entity.RequiresSession;
 
-		if (!requiresSession) {
-			await using ServiceBusReceiver nonSessionReceiver = GetReceiver(entity);
-			ServiceBusReceivedMessage? nonSessionMessage = await nonSessionReceiver.ReceiveMessageAsync(cancellationToken: cancellationToken);
-
-			if (nonSessionMessage is null)
-				return null;
-
-			await nonSessionReceiver.CompleteMessageAsync(nonSessionMessage, cancellationToken);
-			return ConvertToReceivedMessage(nonSessionMessage);
-		}
-
-		await using ServiceBusSessionReceiver receiver = await GetSessionReceiverAsync(entity, sessionId, cancellationToken);
-		ServiceBusReceivedMessage? message = await receiver.ReceiveMessageAsync(cancellationToken: cancellationToken);
-
-		if (message is null)
-			return null;
-
-		await receiver.CompleteMessageAsync(message, cancellationToken);
-		return ConvertToReceivedMessage(message);
+		return entity.RequiresSession
+			? await ReceiveSessionMessageAsync(entity, sessionId, cancellationToken)
+			: await ReceiveNonSessionMessageAsync(entity, cancellationToken);
 	}
 
 	public async Task SendMessageAsync(EntityId entityId, SendCommand command, CancellationToken cancellationToken)
@@ -190,16 +173,61 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 			_ => throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.")
 		};
 
-	private async Task<ServiceBusSessionReceiver> GetSessionReceiverAsync(EntityProperties entity, string? sessionId, CancellationToken cancellationToken)
-		=> entity switch {
-			SubscriptionEntityProperties subscription => string.IsNullOrWhiteSpace(sessionId)
-				? await _client.AcceptNextSessionAsync(subscription.TopicName, subscription.Name, cancellationToken: cancellationToken)
-				: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId, cancellationToken: cancellationToken),
-			QueueEntityProperties queue => string.IsNullOrWhiteSpace(sessionId)
-				? await _client.AcceptNextSessionAsync(queue.Name, cancellationToken: cancellationToken)
-				: await _client.AcceptSessionAsync(queue.Name, sessionId, cancellationToken: cancellationToken),
-			_ => throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.")
-		};
+	private async Task<ReceivedMessage?> ReceiveNonSessionMessageAsync(EntityProperties entity, CancellationToken cancellationToken)
+	{
+		await using ServiceBusReceiver receiver = GetReceiver(entity);
+		ServiceBusReceivedMessage? message = await receiver.ReceiveMessageAsync(_emptyReceiveWaitTime, cancellationToken);
+
+		if (message is null)
+			return null;
+
+		await receiver.CompleteMessageAsync(message, cancellationToken);
+
+		return ConvertToReceivedMessage(message);
+	}
+
+	private async Task<ReceivedMessage?> ReceiveSessionMessageAsync(EntityProperties entity, string? sessionId, CancellationToken cancellationToken)
+	{
+		ServiceBusSessionReceiver? receiver = await TryGetSessionReceiverAsync(entity, sessionId, cancellationToken);
+
+		if (receiver is null)
+			return null;
+
+		await using (receiver) {
+			ServiceBusReceivedMessage? message = await receiver.ReceiveMessageAsync(_emptyReceiveWaitTime, cancellationToken);
+
+			if (message is null)
+				return null;
+
+			await receiver.CompleteMessageAsync(message, cancellationToken);
+
+			return ConvertToReceivedMessage(message);
+		}
+	}
+
+	private async Task<ServiceBusSessionReceiver?> TryGetSessionReceiverAsync(EntityProperties entity, string? sessionId, CancellationToken cancellationToken)
+	{
+		using CancellationTokenSource timeoutCancellationSource = new(_emptyReceiveWaitTime);
+		using CancellationTokenSource linkedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationSource.Token);
+
+		try {
+			return entity switch {
+				SubscriptionEntityProperties subscription => string.IsNullOrWhiteSpace(sessionId)
+					? await _client.AcceptNextSessionAsync(subscription.TopicName, subscription.Name, cancellationToken: linkedCancellationSource.Token)
+					: await _client.AcceptSessionAsync(subscription.TopicName, subscription.Name, sessionId, cancellationToken: linkedCancellationSource.Token),
+				QueueEntityProperties queue => string.IsNullOrWhiteSpace(sessionId)
+					? await _client.AcceptNextSessionAsync(queue.Name, cancellationToken: linkedCancellationSource.Token)
+					: await _client.AcceptSessionAsync(queue.Name, sessionId, cancellationToken: linkedCancellationSource.Token),
+				_ => throw new InvalidOperationException("Topics do not support receiving messages directly. Please select a subscription.")
+			};
+		}
+		catch (OperationCanceledException) when (timeoutCancellationSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested) {
+			return null;
+		}
+		catch (ServiceBusException exception) when (exception.Reason == ServiceBusFailureReason.ServiceTimeout && !cancellationToken.IsCancellationRequested) {
+			return null;
+		}
+	}
 
 	private ServiceBusSender GetSender(EntityProperties entity)
 		=> entity switch {

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.3</Version>
+		<Version>0.40.4</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.4</Version>
+		<Version>0.40.5</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
+++ b/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
@@ -34,7 +34,7 @@ await builder.Build().RunAsync();
 The integration exposes Service Bus Viewer on container port `8080`. You can pin a host port and override the image tag during registration:
 
 ```csharp
-builder.AddServiceBusViewer("servicebusviewer", tag: "0.40.3", httpPort: 8081);
+builder.AddServiceBusViewer("servicebusviewer", tag: "0.40.4", httpPort: 8081);
 ```
 
 ### Configure connection settings with `WithConnectionSettings(...)`


### PR DESCRIPTION
This pull request introduces several important improvements and fixes to Service Bus Viewer, focusing on more predictable receive behavior, improved session handling, and enhanced validation for sending messages. It also includes UI refinements and updates to documentation and versioning.

**Service Bus receive behavior and session handling:**

* Receive operations now treat empty queues or subscriptions as a short-poll and return after about one second, instead of waiting for the Azure Service Bus default timeout. This applies to both session and non-session entities. Session-enabled receives also normalize the "no active session/message" case into the same result as non-session entities. (`.agents/specs/PROJECT_DECISIONS.md` [[1]](diffhunk://#diff-35568874d8efd5f6590f342c45e4968177b388e589630f2309b2d3c5c562f9bcR3-R7) `CHANGELOG.md` [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R8) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R95) `ServiceBusConnection.cs` [[4]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L13-R13) [[5]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L71-R74) [[6]](diffhunk://#diff-e08e7df66c86af76a49e14f501fe2cb606abfe5b7c890543936abf165e3cafe9L193-R230)

* The backend now enforces that a Session ID is required when sending to session-enabled entities, raising a specific validation exception if omitted. (`ViewerMessageService.cs` [[1]](diffhunk://#diff-d19c8886a4b2216f13dcf244ef5b152bd4d6d776ef25f6c198f0d98997579bc4L87-R108) `SendMessageValidationException.cs` [[2]](diffhunk://#diff-933064f7d9a4da7079fe0333288fc3115b4b00f188542485cec6db0e2bf3baf4R1-R4) `ApiExceptionHandler.cs` [[3]](diffhunk://#diff-629527933ab3ca75ea6f90f3fef77a422ff202926228314bb641195d42b84bd7R71)

**Send message form and validation improvements:**

* The send message form now marks the Session ID field as required and updates its placeholder text when sending to session-enabled entities. Client-side validation also enforces this requirement. (`SendMessageForm.tsx` [[1]](diffhunk://#diff-db05716005f7b78398f98da80d10fb71692ab66ca07b809ad4e144e935f7c7e3R52) [[2]](diffhunk://#diff-db05716005f7b78398f98da80d10fb71692ab66ca07b809ad4e144e935f7c7e3R73) [[3]](diffhunk://#diff-db05716005f7b78398f98da80d10fb71692ab66ca07b809ad4e144e935f7c7e3R144-R147) [[4]](diffhunk://#diff-db05716005f7b78398f98da80d10fb71692ab66ca07b809ad4e144e935f7c7e3L239-R255) `ViewerPage.tsx` [[5]](diffhunk://#diff-3df917a7958d7d8a9c08eef3568a09faf37c45e169c75589f52e0018c93bee0cR353-R361)

**UI and accessibility enhancements:**

* The "Refresh" button now shows a spinning icon during refresh and uses `aria-busy` for accessibility. (`ViewerPage.tsx` [src/ServiceBusViewer.Web/src/pages/ViewerPage.tsxR304-R315](diffhunk://#diff-3df917a7958d7d8a9c08eef3568a09faf37c45e169c75589f52e0018c93bee0cR304-R315))
* The "Received Message" section is relabeled as "Last Received Message" for clarity. (`ViewerPage.tsx` [src/ServiceBusViewer.Web/src/pages/ViewerPage.tsxR353-R361](diffhunk://#diff-3df917a7958d7d8a9c08eef3568a09faf37c45e169c75589f52e0018c93bee0cR353-R361))

**Bug fixes:**

* Sending a message no longer clears the last received message details in the UI. (`ViewerPage.tsx` [[1]](diffhunk://#diff-3df917a7958d7d8a9c08eef3568a09faf37c45e169c75589f52e0018c93bee0cL188) `CHANGELOG.md` [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R8) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L90-R95)
