### PR TITLE
feat: add full-message JSON copy button for received and peeked messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Service Bus Viewer Version History
 
-## 0.42.0 (2026-08-19)
+## 0.43.0 (2026-08-20)
 
+- **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The repository also includes the `SolidCode.Aspire.Hosting.ServiceBusViewer` Asp
 - Browse queues, topics, subscriptions, entity properties, and subscription filters.
 - Peek and receive messages from queues or topic subscriptions, including session-enabled entities.
 - View message bodies, system properties, and application properties, with client-side JSON formatting.
+- Copy a received or peeked message body as plain text, or copy the full message as JSON including system and application properties.
 - Send messages to queues or topics with system and typed application properties.
 
 ## Run with Docker
@@ -91,8 +92,9 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.42.0 (2026-08-19)
+## 0.43.0 (2026-08-20)
 
+- **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
+++ b/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
-		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
+		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.0" />
+		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
+import { buildFullMessageJson } from '../../lib/messageJson';
 import { cx } from '../../lib/cx';
 import { tryFormatJsonBody } from '../../lib/jsonFormatting';
+import type { ReceivedMessageDto } from '../../types/serviceBus';
 
 interface JsonMessageBodyProps {
   body: string;
+  fullMessage?: ReceivedMessageDto;
   className?: string;
 }
 
-export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
+const iconButtonClassName =
+  'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800';
+
+export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [fullCopyStatus, setFullCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
@@ -30,18 +37,47 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
     };
   }, [copyStatus]);
 
-  const handleCopyClick = async () => {
+  useEffect(() => {
+    if (fullCopyStatus === 'idle') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setFullCopyStatus('idle');
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [fullCopyStatus]);
+
+  const copyText = async (
+    text: string,
+    setCopyStatus: (status: 'copied' | 'failed') => void,
+  ): Promise<void> => {
     if (!navigator.clipboard?.writeText) {
       setCopyStatus('failed');
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(body);
+      await navigator.clipboard.writeText(text);
       setCopyStatus('copied');
     } catch {
       setCopyStatus('failed');
     }
+  };
+
+  const handleCopyClick = async () => {
+    await copyText(body, setCopyStatus);
+  };
+
+  const handleFullCopyClick = async () => {
+    if (!fullMessage) {
+      return;
+    }
+
+    await copyText(buildFullMessageJson(fullMessage), setFullCopyStatus);
   };
 
   return (
@@ -67,7 +103,7 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
           </span>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+            className={iconButtonClassName}
             onClick={handleCopyClick}
             aria-label="Copy message body"
             title="Copy message body"
@@ -76,6 +112,35 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
               content_copy
             </span>
           </button>
+          {fullMessage ? (
+            <>
+              <button
+                type="button"
+                className={iconButtonClassName}
+                onClick={handleFullCopyClick}
+                aria-label="Copy full message as JSON"
+                title="Copy full message as JSON"
+              >
+                <span className="material-icons-round text-sm" aria-hidden="true">
+                  data_object
+                </span>
+              </button>
+              <span
+                aria-live="polite"
+                className={cx(
+                  'text-[11px] font-medium',
+                  fullCopyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
+                  fullCopyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
+                )}
+              >
+                {fullCopyStatus === 'copied'
+                  ? 'Copied JSON'
+                  : fullCopyStatus === 'failed'
+                    ? 'Copy failed'
+                    : null}
+              </span>
+            </>
+          ) : null}
           <button
             type="button"
             className={cx(

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -10,14 +10,15 @@ interface JsonMessageBodyProps {
   className?: string;
 }
 
+type CopyStatus = 'idle' | 'copied' | 'copied-json' | 'failed';
+
 const iconButtonClassName =
   'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800';
 
 export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
-  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
-  const [fullCopyStatus, setFullCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
@@ -37,24 +38,7 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
     };
   }, [copyStatus]);
 
-  useEffect(() => {
-    if (fullCopyStatus === 'idle') {
-      return undefined;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setFullCopyStatus('idle');
-    }, 2000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [fullCopyStatus]);
-
-  const copyText = async (
-    text: string,
-    setCopyStatus: (status: 'copied' | 'failed') => void,
-  ): Promise<void> => {
+  const copyText = async (text: string, successStatus: 'copied' | 'copied-json'): Promise<void> => {
     if (!navigator.clipboard?.writeText) {
       setCopyStatus('failed');
       return;
@@ -62,14 +46,14 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
 
     try {
       await navigator.clipboard.writeText(text);
-      setCopyStatus('copied');
+      setCopyStatus(successStatus);
     } catch {
       setCopyStatus('failed');
     }
   };
 
   const handleCopyClick = async () => {
-    await copyText(body, setCopyStatus);
+    await copyText(body, 'copied');
   };
 
   const handleFullCopyClick = async () => {
@@ -77,7 +61,7 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
       return;
     }
 
-    await copyText(buildFullMessageJson(fullMessage), setFullCopyStatus);
+    await copyText(buildFullMessageJson(fullMessage), 'copied-json');
   };
 
   return (
@@ -91,15 +75,18 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
             aria-live="polite"
             className={cx(
               'text-[11px] font-medium',
-              copyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
+              (copyStatus === 'copied' || copyStatus === 'copied-json') &&
+                'text-emerald-600 dark:text-emerald-400',
               copyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
             )}
           >
             {copyStatus === 'copied'
               ? 'Copied'
-              : copyStatus === 'failed'
-                ? 'Copy failed'
-                : null}
+              : copyStatus === 'copied-json'
+                ? 'Copied JSON'
+                : copyStatus === 'failed'
+                  ? 'Copy failed'
+                  : null}
           </span>
           <button
             type="button"
@@ -113,33 +100,17 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
             </span>
           </button>
           {fullMessage ? (
-            <>
-              <button
-                type="button"
-                className={iconButtonClassName}
-                onClick={handleFullCopyClick}
-                aria-label="Copy full message as JSON"
-                title="Copy full message as JSON"
-              >
-                <span className="material-icons-round text-sm" aria-hidden="true">
-                  data_object
-                </span>
-              </button>
-              <span
-                aria-live="polite"
-                className={cx(
-                  'text-[11px] font-medium',
-                  fullCopyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
-                  fullCopyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
-                )}
-              >
-                {fullCopyStatus === 'copied'
-                  ? 'Copied JSON'
-                  : fullCopyStatus === 'failed'
-                    ? 'Copy failed'
-                    : null}
+            <button
+              type="button"
+              className={iconButtonClassName}
+              onClick={handleFullCopyClick}
+              aria-label="Copy full message as JSON"
+              title="Copy full message as JSON"
+            >
+              <span className="material-icons-round text-sm" aria-hidden="true">
+                data_object
               </span>
-            </>
+            </button>
           ) : null}
           <button
             type="button"

--- a/src/ServiceBusViewer.Web/src/lib/messageJson.ts
+++ b/src/ServiceBusViewer.Web/src/lib/messageJson.ts
@@ -1,0 +1,13 @@
+import type { ReceivedMessageDto } from '../types/serviceBus';
+
+export function buildFullMessageJson(message: ReceivedMessageDto): string {
+	return JSON.stringify(
+		{
+			body: message.body,
+			properties: message.properties,
+			applicationProperties: message.applicationProperties,
+		},
+		undefined,
+		2,
+	);
+}

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -439,7 +439,11 @@ export function ViewerPage() {
 												</div>
 											</div>
 
-											<JsonMessageBody body={currentViewer.displayedMessage.body} className="mt-6" />
+											<JsonMessageBody
+												body={currentViewer.displayedMessage.body}
+												fullMessage={currentViewer.displayedMessage}
+												className="mt-6"
+											/>
 										</>
 									) : (
 										<div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-400">
@@ -555,7 +559,11 @@ export function ViewerPage() {
 																			</div>
 																		</div>
 
-																		<JsonMessageBody body={message.body} className="mt-4" />
+																		<JsonMessageBody
+																			body={message.body}
+																			fullMessage={message}
+																			className="mt-4"
+																		/>
 																	</td>
 																</tr>
 															) : null}

--- a/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
+++ b/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
@@ -17,6 +17,12 @@ internal static class ResponseMapping
 			Guid guid => guid.ToString(),
 			char character => character.ToString(),
 			byte[] bytes => Convert.ToBase64String(bytes),
+
+			// Preserve values that may exceed JavaScript's safe numeric precision so client-side JSON export remains exact.
+			long number => number.ToString(CultureInfo.InvariantCulture),
+			ulong number => number.ToString(CultureInfo.InvariantCulture),
+			decimal number => number.ToString(CultureInfo.InvariantCulture),
+
 			_ => value
 		};
 

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.42.0</Version>
+		<Version>0.43.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
## Summary

Adds a "copy full message as JSON" button for received and peeked messages, alongside the existing body-only copy action. The new button copies the message body, system properties, and application properties as valid, pretty-printed JSON.

## Changes

**Frontend (`ServiceBusViewer.Web`)**
- `JsonMessageBody` now accepts an optional `fullMessage` prop and renders a second copy button (`data_object` icon) that copies the full message as JSON, with a distinct "Copied JSON" status
- New `lib/messageJson.ts` helper `buildFullMessageJson` builds the `{ body, properties, applicationProperties }` JSON payload
- `ViewerPage` passes the displayed/peeked message into `JsonMessageBody` for both the viewer panel and the peeked messages table

**Backend (`ServiceBusViewer`)**
- `ResponseMapping` now serializes `long`, `ulong`, and `decimal` application properties as invariant-culture strings so values beyond JavaScript's safe numeric precision survive the API round-trip and the client-side JSON export remains exact

## Other
- Bumped version to 0.43.0
- Updated Aspire SDK and package references to 13.5.0