### PR TITLE
feat: Paste full message JSON into send window with duplicate-detecti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Service Bus Viewer Version History
 
-## 0.43.0 (2026-08-20)
+## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
+- **Added:** Paste-from-clipboard action in the Send Message window that loads a full-message JSON payload copied from a received or peeked message into the payload editor, message properties, and application properties, updating only the fields present in the JSON.
+- **Added:** Warning indicator on the Message ID field when the selected queue or topic (the parent topic of a selected subscription) has duplicate detection enabled and the pasted JSON carries a non-empty message ID; the warning resets when the message ID is edited or after a successful send, and a failed send keeps it.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.43.0 (2026-08-20)
+## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
+- **Added:** Paste-from-clipboard action in the Send Message window that loads a full-message JSON payload copied from a received or peeked message into the payload editor, message properties, and application properties, updating only the fields present in the JSON.
+- **Added:** Warning indicator on the Message ID field when the selected queue or topic (the parent topic of a selected subscription) has duplicate detection enabled and the pasted JSON carries a non-empty message ID; the warning resets when the message ID is edited or after a successful send, and a failed send keeps it.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
+++ b/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
@@ -7,7 +7,7 @@
 
         "queues": [
           {
-            "name": "queue1",
+            "name": "queue",
             "properties": {
               "lockDuration": "PT5M",
               "requiresDuplicateDetection": false,
@@ -22,7 +22,22 @@
           },
 
           {
-            "name": "queue2-with-session",
+            "name": "queue-with-duplicate-detection",
+            "properties": {
+              "lockDuration": "PT5M",
+              "requiresDuplicateDetection": true,
+              "requiresSession": false,
+              "defaultMessageTimeToLive": "PT1H",
+              "deadLetteringOnMessageExpiration": true,
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "maxDeliveryCount": 10,
+              "status": "Active"
+            }
+          },
+
+          {
+            "name": "queue-with-sessions",
             "properties": {
               "lockDuration": "PT5M",
               "requiresDuplicateDetection": false,

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -88,17 +88,6 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
                   ? 'Copy failed'
                   : null}
           </span>
-          <button
-            type="button"
-            className={iconButtonClassName}
-            onClick={handleCopyClick}
-            aria-label="Copy message body"
-            title="Copy message body"
-          >
-            <span className="material-icons-round text-sm" aria-hidden="true">
-              content_copy
-            </span>
-          </button>
           {fullMessage ? (
             <button
               type="button"
@@ -112,6 +101,17 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
               </span>
             </button>
           ) : null}
+          <button
+            type="button"
+            className={cx(iconButtonClassName, 'ml-2')}
+            onClick={handleCopyClick}
+            aria-label="Copy message body"
+            title="Copy message body"
+          >
+            <span className="material-icons-round text-sm" aria-hidden="true">
+              content_copy
+            </span>
+          </button>
           <button
             type="button"
             className={cx(

--- a/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
+++ b/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
@@ -1,13 +1,8 @@
-import {
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type ChangeEvent,
-	type FormEvent,
-} from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { serviceBusApi } from '../../api/serviceBusApi';
 import { useStoredBoolean } from '../../hooks/useStoredBoolean';
 import { cx } from '../../lib/cx';
+import { parseSendWindowJson } from '../../lib/sendWindowJsonImport';
 import type {
 	ApplicationPropertyInputDto,
 	ApplicationPropertyType,
@@ -50,6 +45,8 @@ interface SendMessageFormProps {
 	canSend: boolean;
 	isSubmitting: boolean;
 	requiresSession: boolean;
+	entityName: string | null;
+	topicName: string | null;
 	onSubmit: (request: SendMessageRequestDto) => Promise<void>;
 	onValidationError: (messages: string[]) => void;
 }
@@ -67,10 +64,19 @@ function createProperty(): ApplicationPropertyInputDto {
 	return { key: '', type: 'String', value: '' };
 }
 
+const messageIdFieldClasses =
+	'block w-full rounded-xl border bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20';
+const messageIdFieldNormalClasses =
+	'border-slate-200 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:focus:border-brand-400';
+const messageIdFieldWarningClasses =
+	'border-amber-400 bg-amber-50/60 focus:border-amber-500 focus:ring-2 focus:ring-amber-500/20 dark:border-amber-600/70 dark:bg-amber-950/20 dark:focus:border-amber-500';
+
 export function SendMessageForm({
 	canSend,
 	isSubmitting,
 	requiresSession,
+	entityName,
+	topicName,
 	onSubmit,
 	onValidationError,
 }: SendMessageFormProps) {
@@ -84,6 +90,97 @@ export function SendMessageForm({
 	const [isContentTypeMenuOpen, setIsContentTypeMenuOpen] = useState(false);
 	const [contentTypeFilter, setContentTypeFilter] = useState('');
 	const contentTypeContainerRef = useRef<HTMLDivElement | null>(null);
+	const [duplicateDetection, setDuplicateDetection] = useState<boolean | null>(null);
+	const [loadJsonStatus, setLoadJsonStatus] = useState<{
+		kind: 'error';
+		message: string;
+	} | null>(null);
+	const [loadJsonStatusFading, setLoadJsonStatusFading] = useState(false);
+	const loadJsonStatusTimerRef = useRef<number | null>(null);
+	const loadJsonFadeTimerRef = useRef<number | null>(null);
+	const [duplicateDetectionArmed, setDuplicateDetectionArmed] = useState(false);
+
+	const clearLoadJsonStatusTimers = () => {
+		if (loadJsonStatusTimerRef.current !== null) {
+			window.clearTimeout(loadJsonStatusTimerRef.current);
+			loadJsonStatusTimerRef.current = null;
+		}
+		if (loadJsonFadeTimerRef.current !== null) {
+			window.clearTimeout(loadJsonFadeTimerRef.current);
+			loadJsonFadeTimerRef.current = null;
+		}
+	};
+
+	const clearLoadJsonStatus = () => {
+		clearLoadJsonStatusTimers();
+		setLoadJsonStatus(null);
+		setLoadJsonStatusFading(false);
+	};
+
+	const showLoadJsonError = (message: string) => {
+		clearLoadJsonStatusTimers();
+		setLoadJsonStatus({ kind: 'error', message });
+		setLoadJsonStatusFading(false);
+		loadJsonStatusTimerRef.current = window.setTimeout(() => {
+			loadJsonStatusTimerRef.current = null;
+			setLoadJsonStatusFading(true);
+			loadJsonFadeTimerRef.current = window.setTimeout(() => {
+				loadJsonFadeTimerRef.current = null;
+				setLoadJsonStatus(null);
+				setLoadJsonStatusFading(false);
+			}, 500);
+		}, 5000);
+	};
+
+	useEffect(() => clearLoadJsonStatusTimers, []);
+
+	const duplicateDetectionWarning = duplicateDetection === true && duplicateDetectionArmed;
+
+	const messageIdValueRef = useRef(messageProperties.messageId);
+
+	useEffect(() => {
+		messageIdValueRef.current = messageProperties.messageId;
+	}, [messageProperties.messageId]);
+
+	useEffect(() => {
+		if (duplicateDetection === true && messageIdValueRef.current.length > 0) {
+			setDuplicateDetectionArmed(true);
+		}
+	}, [duplicateDetection]);
+
+	useEffect(() => {
+		setDuplicateDetectionArmed(false);
+		setDuplicateDetection(null);
+
+		const detailsType = topicName ? 'Topic' : 'Queue';
+		const detailsName = topicName ?? entityName;
+		if (!detailsName) {
+			return;
+		}
+
+		let isDisposed = false;
+		void serviceBusApi
+			.getEntityDetails(detailsType, detailsName, null)
+			.then((details) => {
+				if (isDisposed || details.properties === null) {
+					return;
+				}
+				const requiresDuplicate =
+					'requiresDuplicateDetection' in details.properties
+						? Boolean(details.properties.requiresDuplicateDetection)
+						: false;
+				setDuplicateDetection(requiresDuplicate);
+			})
+			.catch(() => {
+				if (!isDisposed) {
+					setDuplicateDetection(null);
+				}
+			});
+
+		return () => {
+			isDisposed = true;
+		};
+	}, [entityName, topicName]);
 
 	useEffect(() => {
 		if (!isContentTypeMenuOpen) {
@@ -158,6 +255,8 @@ export function SendMessageForm({
 		setApplicationProperties([]);
 		setIsContentTypeMenuOpen(false);
 		setContentTypeFilter('');
+		clearLoadJsonStatus();
+		// A successful send is the warning reset: do not re-arm here.
 	};
 
 	const handlePropertiesChange = (
@@ -173,6 +272,9 @@ export function SendMessageForm({
 			setContentTypeFilter(value);
 			setIsContentTypeMenuOpen(true);
 		}
+		if (key === 'messageId' && duplicateDetectionWarning) {
+			setDuplicateDetectionArmed(false);
+		}
 	};
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -183,15 +285,66 @@ export function SendMessageForm({
 			return;
 		}
 
-		await onSubmit({
-			sendMessageApplicationProperties: applicationProperties,
-			sendMessageBody: messageBody,
-			sendMessageProperties: {
-				...messageProperties,
-				scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
-			},
-		});
+		clearLoadJsonStatus();
+
+		try {
+			await onSubmit({
+				sendMessageApplicationProperties: applicationProperties,
+				sendMessageBody: messageBody,
+				sendMessageProperties: {
+					...messageProperties,
+					scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
+				},
+			});
+		} catch {
+			return;
+		}
+
+		setDuplicateDetectionArmed(false);
 		resetForm();
+	};
+
+	const handleLoadJson = async () => {
+		clearLoadJsonStatus();
+		let pastedText: string;
+		try {
+			pastedText = await navigator.clipboard.readText();
+		} catch {
+			showLoadJsonError(
+				'Clipboard access was blocked. Allow clipboard access and try again, or paste the JSON into the payload manually.',
+			);
+			return;
+		}
+
+		if (pastedText.length === 0) {
+			showLoadJsonError('The clipboard is empty. Copy a full message as JSON first.');
+			return;
+		}
+
+		const result = parseSendWindowJson(pastedText);
+		if (!result.ok) {
+			showLoadJsonError(result.error);
+			return;
+		}
+
+		if (result.value.body !== null) {
+			setMessageBody(result.value.body);
+		}
+
+		const importedProperties = result.value.properties;
+		if (importedProperties && Object.keys(importedProperties).length > 0) {
+			setMessageProperties((current) => ({ ...current, ...importedProperties }));
+		}
+
+		const importedApplicationProperties = result.value.applicationProperties;
+		if (importedApplicationProperties) {
+			setApplicationProperties(importedApplicationProperties);
+		}
+
+		const pastedMessageId = result.value.properties?.messageId;
+		if (duplicateDetection === true && pastedMessageId !== undefined && pastedMessageId.length > 0) {
+			setDuplicateDetectionArmed(true);
+		}
 	};
 
 	return (
@@ -200,16 +353,42 @@ export function SendMessageForm({
 				<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
 					Send Message
 				</h2>
-				<button
-					type="button"
-					className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
-					onClick={() => setIsOpen((current) => !current)}
-				>
-					<span className="material-icons-round text-sm">
-						{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-					</span>
-					<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
-				</button>
+				<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+					{isOpen && loadJsonStatus ? (
+						<span
+							role="alert"
+							className={cx(
+								'max-w-full truncate text-xs font-medium text-rose-700 transition-opacity duration-500 dark:text-rose-300',
+								loadJsonStatusFading && 'opacity-0',
+							)}
+						>
+							{loadJsonStatus.message}
+						</span>
+					) : null}
+					<button
+						type="button"
+						disabled={!isOpen}
+						className={cx(
+							'inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-500 transition hover:border-slate-300 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:text-white',
+							!isOpen && 'cursor-not-allowed opacity-40 hover:border-slate-200 hover:text-slate-500 dark:hover:border-slate-800 dark:hover:text-slate-300',
+						)}
+						onClick={() => void handleLoadJson()}
+						title="Paste the full message JSON from the clipboard into this form"
+					>
+						<span className="material-icons-round text-sm">content_paste</span>
+						Paste From Clipboard
+					</button>
+					<button
+						type="button"
+						className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
+						onClick={() => setIsOpen((current) => !current)}
+					>
+						<span className="material-icons-round text-sm">
+							{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+						</span>
+						<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
+					</button>
+				</div>
 			</div>
 
 			<div className={cx('send-form-transition', !isOpen && 'js-send-form-hidden')}>
@@ -229,17 +408,33 @@ export function SendMessageForm({
 
 						<div className="space-y-4">
 							<div>
-								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+								<label className="mb-2 flex items-center justify-between pr-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 									Message ID
+									{duplicateDetectionWarning ? (
+										<span
+											id="messageIdDuplicateDetectionWarning"
+											className="flex items-center gap-1 normal-case tracking-normal text-xs font-medium text-amber-700 dark:text-amber-400"
+										>
+											<span className="material-icons-round text-sm" aria-hidden="true">warning_amber</span>
+											<span>Duplicate detection enabled</span>
+										</span>
+									) : null}
 								</label>
 								<input
 									type="text"
 									maxLength={128}
-									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-									value={messageProperties.messageId}
-									onChange={(event) => handlePropertiesChange('messageId', event)}
-								/>
-							</div>
+									aria-invalid={duplicateDetectionWarning || undefined}
+									aria-describedby={duplicateDetectionWarning ? 'messageIdDuplicateDetectionWarning' : undefined}
+									className={cx(
+										messageIdFieldClasses,
+										duplicateDetectionWarning
+											? messageIdFieldWarningClasses
+											: messageIdFieldNormalClasses,
+									)}
+								value={messageProperties.messageId}
+								onChange={(event) => handlePropertiesChange('messageId', event)}
+							/>
+						</div>
 
 							<div>
 								<label className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -380,7 +575,7 @@ export function SendMessageForm({
 					</div>
 
 					<div className="mt-6">
-						<div className="mb-3 flex items-center justify-between gap-3">
+						<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
 							<div>
 								<label className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 									Application Properties
@@ -389,23 +584,25 @@ export function SendMessageForm({
 									Optional typed key-value metadata to attach to the outgoing message.
 								</p>
 							</div>
-							<button
-								type="button"
-								className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
-								onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
-							>
-								<svg
-									className="h-4 w-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="1.8"
-									aria-hidden="true"
+							<div className="flex flex-wrap items-center gap-2">
+								<button
+									type="button"
+									className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+									onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
 								>
-									<path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
-								</svg>
-								Add Property
-							</button>
+									<svg
+										className="h-4 w-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="1.8"
+										aria-hidden="true"
+									>
+										<path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+									</svg>
+									Add Property
+								</button>
+							</div>
 						</div>
 
 						<div className="space-y-3">

--- a/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
+++ b/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
@@ -1,0 +1,204 @@
+import type {
+	ApplicationPropertyInputDto,
+	ApplicationPropertyType,
+	SendMessagePropertiesDto,
+} from '../types/serviceBus';
+
+const applicationPropertyTypeNames: ReadonlySet<string> = new Set([
+	'String',
+	'Bool',
+	'Byte',
+	'ByteArray',
+	'SByte',
+	'Short',
+	'UShort',
+	'Int',
+	'UInt',
+	'Long',
+	'ULong',
+	'Float',
+	'Double',
+	'Decimal',
+	'Char',
+	'Guid',
+	'DateTime',
+	'DateTimeOffset',
+	'TimeSpan',
+	'Null',
+	'Unknown',
+]);
+
+const supportedPropertyKeys = [
+	'messageId',
+	'sessionId',
+	'correlationId',
+	'contentType',
+	'scheduledEnqueueTime',
+	'timeToLive',
+] as const satisfies readonly (keyof SendMessagePropertiesDto)[];
+
+export type SendWindowJsonImport = {
+	body: string | null;
+	properties: Partial<SendMessagePropertiesDto> | null;
+	applicationProperties: ApplicationPropertyInputDto[] | null;
+};
+
+export type SendWindowJsonImportResult =
+	| { ok: true; value: SendWindowJsonImport }
+	| { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function toSendValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return '';
+	}
+
+	if (typeof value === 'string' || typeof value === 'boolean') {
+		return String(value);
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? String(value) : JSON.stringify(value);
+	}
+
+	if (typeof value === 'bigint') {
+		return value.toString();
+	}
+
+	return JSON.stringify(value);
+}
+
+function toDatetimeLocalValue(iso: string): string {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	const pad = (component: number) => String(component).padStart(2, '0');
+	return [
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+		`${pad(date.getHours())}:${pad(date.getMinutes())}`,
+	].join('T');
+}
+
+function parseStringProperty(
+	properties: Record<string, unknown>,
+	key: (typeof supportedPropertyKeys)[number],
+): string | undefined {
+	if (!(key in properties)) {
+		return undefined;
+	}
+
+	const raw = properties[key];
+	if (raw === null || raw === undefined) {
+		return '';
+	}
+
+	if (typeof raw !== 'string') {
+		throw new Error(`Property '${key}' must be a string.`);
+	}
+
+	if (key === 'scheduledEnqueueTime') {
+		return toDatetimeLocalValue(raw);
+	}
+
+	return raw;
+}
+
+function parseApplicationProperties(
+	raw: Record<string, unknown> | null,
+): ApplicationPropertyInputDto[] {
+	if (raw === null) {
+		return [];
+	}
+
+	const rows: ApplicationPropertyInputDto[] = [];
+	for (const [key, entry] of Object.entries(raw)) {
+		if (!isRecord(entry) || !('value' in entry)) {
+			throw new Error(`Application property '${key}' must be an object with a value.`);
+		}
+
+		const type = entry.type;
+		if (typeof type !== 'string' || !applicationPropertyTypeNames.has(type)) {
+			throw new Error(`Application property '${key}' has an unsupported type.`);
+		}
+
+		rows.push({
+			key,
+			type: type as ApplicationPropertyType,
+			value: toSendValue(entry['value']),
+		});
+	}
+
+	return rows;
+}
+
+export function parseSendWindowJson(text: string): SendWindowJsonImportResult {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return { ok: false, error: 'The clipboard text is not valid JSON.' };
+	}
+
+	if (!isRecord(parsed)) {
+		return { ok: false, error: 'The pasted JSON must be an object with message fields.' };
+	}
+
+	try {
+		const value: SendWindowJsonImport = {
+			body: null,
+			properties: null,
+			applicationProperties: null,
+		};
+
+		if ('body' in parsed) {
+			if (typeof parsed.body !== 'string') {
+				throw new Error("The 'body' field must be a string.");
+			}
+			value.body = parsed.body;
+		}
+
+		if ('properties' in parsed) {
+			const rawProperties = parsed.properties;
+			if (!isRecord(rawProperties)) {
+				throw new Error("'properties' must be an object.");
+			}
+
+			const patch: Partial<SendMessagePropertiesDto> = {};
+			let hasSupportedProperty = false;
+			for (const key of supportedPropertyKeys) {
+				const mapped = parseStringProperty(rawProperties, key);
+				if (mapped !== undefined) {
+					patch[key] = mapped;
+					hasSupportedProperty = true;
+				}
+			}
+			value.properties = hasSupportedProperty ? patch : {};
+		}
+
+		if ('applicationProperties' in parsed) {
+			const rawApplicationProperties = parsed.applicationProperties;
+			if (rawApplicationProperties !== null && !isRecord(rawApplicationProperties)) {
+				throw new Error("'applicationProperties' must be an object or null.");
+			}
+			value.applicationProperties = parseApplicationProperties(
+				rawApplicationProperties === null ? null : rawApplicationProperties,
+			);
+		}
+
+		return { ok: true, value };
+	} catch (error: unknown) {
+		const message =
+			error instanceof Error ? error.message : 'The pasted JSON does not match the expected message format.';
+		return { ok: false, error: message };
+	}
+}

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -92,8 +92,10 @@ export function ViewerPage() {
 
 			try {
 				await work();
+				return true;
 			} catch (error: unknown) {
 				setErrorMessages(getErrorMessages(error));
+				return false;
 			} finally {
 				setPendingAction(null);
 			}
@@ -180,7 +182,7 @@ export function ViewerPage() {
 	};
 
 	const handleSend = async (request: SendMessageRequestDto) => {
-		await runAction('send', async () => {
+		const succeeded = await runAction('send', async () => {
 			await serviceBusApi.send(request);
 
 			if (currentViewer) {
@@ -200,6 +202,9 @@ export function ViewerPage() {
 				]);
 			}
 		});
+		if (!succeeded) {
+			throw new Error('The message was not sent.');
+		}
 	};
 
 	const renderApplicationPropertiesTable = (
@@ -352,13 +357,15 @@ export function ViewerPage() {
 								tone="success"
 							/>
 
-							<SendMessageForm
-								canSend={Boolean(currentViewer?.entityName)}
-								isSubmitting={pendingAction === 'send'}
-								requiresSession={Boolean(currentViewer?.requiresSession)}
-								onSubmit={handleSend}
-								onValidationError={setErrorMessages}
-							/>
+						<SendMessageForm
+							canSend={Boolean(currentViewer?.entityName)}
+							entityName={currentViewer?.entityName ?? null}
+							isSubmitting={pendingAction === 'send'}
+							requiresSession={Boolean(currentViewer?.requiresSession)}
+							topicName={currentViewer?.topicName ?? null}
+							onSubmit={handleSend}
+							onValidationError={setErrorMessages}
+						/>
 
 							<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
 								<div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/40">

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.43.0</Version>
+		<Version>0.45.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
feat: Paste full message JSON into send window with duplicate-detection warning

- Add "Paste From Clipboard" action in the Send Message header that loads a
  full-message JSON payload into the payload, message properties, and
  application properties, updating only fields present in the JSON
- Warn on the Message ID field when duplicate detection is enabled on the
  selected entity and the pasted JSON carries a non-empty message ID; the
  warning resets on ID edit or successful send and persists across failed sends
- A failed send no longer clears the send form
- Reorder copy buttons so full-message JSON copy precedes body-only copy
- Rename emulator queues and add a duplicate-detection queue
- Bump version to 0.45.0