### PR TITLE
Version 0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Service Bus Viewer Version History
 
-## 0.42.0 (2026-08-19)
+## 0.43.0 (2026-08-20)
 
+- **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Service Bus Viewer Version History
 
-## 0.43.0 (2026-08-20)
+## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
+- **Added:** Paste-from-clipboard action in the Send Message window that loads a full-message JSON payload copied from a received or peeked message into the payload editor, message properties, and application properties, updating only the fields present in the JSON.
+- **Added:** Warning indicator on the Message ID field when the selected queue or topic (the parent topic of a selected subscription) has duplicate detection enabled and the pasted JSON carries a non-empty message ID; the warning resets when the message ID is edited or after a successful send, and a failed send keeps it.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Service Bus Viewer Version History
 
+## 0.41.0 (2026-08-19)
+
+- **Added:** Received and peeked message details now display each application property's type alongside its name and value.
+
 ## 0.40.5 (2026-08-17)
 
 - **Added:** Introduced the `SolidCode.Aspire.Hosting.ServiceBusViewer` hosting library for running the published Service Bus Viewer container from Aspire AppHosts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Service Bus Viewer Version History
 
-## 0.41.0 (2026-08-19)
+## 0.42.0 (2026-08-19)
 
+- **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 
 ## 0.40.5 (2026-08-17)
@@ -77,3 +78,4 @@
 ## 0.5.0 (2025-05-26)
 
 - Initial version.
+

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The repository also includes the `SolidCode.Aspire.Hosting.ServiceBusViewer` Asp
 - Browse queues, topics, subscriptions, entity properties, and subscription filters.
 - Peek and receive messages from queues or topic subscriptions, including session-enabled entities.
 - View message bodies, system properties, and application properties, with client-side JSON formatting.
+- Copy a received or peeked message body as plain text, or copy the full message as JSON including system and application properties.
 - Send messages to queues or topics with system and typed application properties.
 
 ## Run with Docker
@@ -91,8 +92,9 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.42.0 (2026-08-19)
+## 0.43.0 (2026-08-20)
 
+- **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ When the viewer runs directly on the host, use:
 
 ```text
 Endpoint=sb://localhost;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+```
+```text
 Endpoint=sb://localhost:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
 ```
 
@@ -77,6 +79,8 @@ When the viewer runs in a container and the emulator runs on the host, use:
 
 ```text
 Endpoint=sb://host.docker.internal;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
+```
+```text
 Endpoint=sb://host.docker.internal:5300;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=SAS_KEY_VALUE;UseDevelopmentEmulator=true;
 ```
 
@@ -86,6 +90,10 @@ The API keeps viewer state in a server-side bucket identified by the `sbv-sessio
 Tabs that share the same browser cookie jar also share the same Service Bus Viewer session.
 
 ## Version history
+
+## 0.41.0 (2026-08-19)
+
+- **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 
 ## 0.40.5 (2026-08-17)
 
@@ -106,13 +114,6 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 - **Fixed:** Failed connection attempts during initial message peeking no longer leave the browser session marked as connected, allowing immediate retry with corrected credentials.
 - **Fixed:** A queue, topic, or subscription supplied with a management-capable connection is retained as the initial viewer selection.
 - **Fixed:** Long expanded message bodies increasing the width of the Peeked Messages table.
-
-## 0.30.0 (2026-08-09)
-
-- Replaced the Razor UI with a React + Vite SPA and reorganized the backend as a minimal API.
-- Isolated viewer state and Service Bus connections by browser session.
-- Added centralized RFC `ProblemDetails` API error handling.
-- Consolidated production deployment into one ASP.NET Core container that serves both the SPA and API.
 
 See the [full changelog](CHANGELOG.md) for the complete version history.
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.41.0 (2026-08-19)
+## 0.42.0 (2026-08-19)
 
+- **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 
 ## 0.40.5 (2026-08-17)
@@ -211,3 +212,4 @@ The release workflows publish the combined image.
 Copyright © 2025–2026 Andrey Veselov.
 
 This project is distributed under the [MIT License](LICENSE).
+

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.43.0 (2026-08-20)
+## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
+- **Added:** Paste-from-clipboard action in the Send Message window that loads a full-message JSON payload copied from a received or peeked message into the payload editor, message properties, and application properties, updating only the fields present in the JSON.
+- **Added:** Warning indicator on the Message ID field when the selected queue or topic (the parent topic of a selected subscription) has duplicate detection enabled and the pasted JSON carries a non-empty message ID; the warning resets when the message ID is edited or after a successful send, and a failed send keeps it.
 - **Added:** Copy button for received and peeked message bodies that copies the original message body text as plain text.
 - **Added:** Received and peeked message details now display each application property's type alongside its name and value.
 

--- a/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
+++ b/src/ServiceBusViewer.AppHost/ServiceBusConfig.json
@@ -7,7 +7,7 @@
 
         "queues": [
           {
-            "name": "queue1",
+            "name": "queue",
             "properties": {
               "lockDuration": "PT5M",
               "requiresDuplicateDetection": false,
@@ -22,7 +22,22 @@
           },
 
           {
-            "name": "queue2-with-session",
+            "name": "queue-with-duplicate-detection",
+            "properties": {
+              "lockDuration": "PT5M",
+              "requiresDuplicateDetection": true,
+              "requiresSession": false,
+              "defaultMessageTimeToLive": "PT1H",
+              "deadLetteringOnMessageExpiration": true,
+              "enableBatchedOperations": true,
+              "duplicateDetectionHistoryTimeWindow": "PT5M",
+              "maxDeliveryCount": 10,
+              "status": "Active"
+            }
+          },
+
+          {
+            "name": "queue-with-sessions",
             "properties": {
               "lockDuration": "PT5M",
               "requiresDuplicateDetection": false,

--- a/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
+++ b/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.4.6">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.4.6" />
-		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.4.6" />
+		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.0" />
+		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -10,10 +10,39 @@ interface JsonMessageBodyProps {
 export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
   }, [formattedJson]);
+
+  useEffect(() => {
+    if (copyStatus === 'idle') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setCopyStatus('idle');
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [copyStatus]);
+
+  const handleCopyClick = async () => {
+    if (!navigator.clipboard?.writeText) {
+      setCopyStatus('failed');
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(body);
+      setCopyStatus('copied');
+    } catch {
+      setCopyStatus('failed');
+    }
+  };
 
   return (
     <div className={cx('js-message-container', className)}>
@@ -21,21 +50,48 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
         <h3 className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
           Message Body
         </h3>
-        <button
-          type="button"
-          className={cx(
-            'js-json-toggle items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800',
-            formattedJson && 'js-json-toggle-visible',
-          )}
-          aria-pressed={isFormatted}
-          onClick={() => {
-            if (formattedJson) {
-              setIsFormatted((current) => !current);
-            }
-          }}
-        >
-          {isFormatted ? 'Raw' : 'Formatted'}
-        </button>
+        <div className="flex items-center gap-2">
+          <span
+            aria-live="polite"
+            className={cx(
+              'text-[11px] font-medium',
+              copyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
+              copyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
+            )}
+          >
+            {copyStatus === 'copied'
+              ? 'Copied'
+              : copyStatus === 'failed'
+                ? 'Copy failed'
+                : null}
+          </span>
+          <button
+            type="button"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+            onClick={handleCopyClick}
+            aria-label="Copy message body"
+            title="Copy message body"
+          >
+            <span className="material-icons-round text-sm" aria-hidden="true">
+              content_copy
+            </span>
+          </button>
+          <button
+            type="button"
+            className={cx(
+              'js-json-toggle inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800',
+              formattedJson && 'js-json-toggle-visible',
+            )}
+            aria-pressed={isFormatted}
+            onClick={() => {
+              if (formattedJson) {
+                setIsFormatted((current) => !current);
+              }
+            }}
+          >
+            {isFormatted ? 'Raw' : 'Formatted'}
+          </button>
+        </div>
       </div>
 
       {formattedJson && isFormatted ? (

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -88,17 +88,6 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
                   ? 'Copy failed'
                   : null}
           </span>
-          <button
-            type="button"
-            className={iconButtonClassName}
-            onClick={handleCopyClick}
-            aria-label="Copy message body"
-            title="Copy message body"
-          >
-            <span className="material-icons-round text-sm" aria-hidden="true">
-              content_copy
-            </span>
-          </button>
           {fullMessage ? (
             <button
               type="button"
@@ -112,6 +101,17 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
               </span>
             </button>
           ) : null}
+          <button
+            type="button"
+            className={cx(iconButtonClassName, 'ml-2')}
+            onClick={handleCopyClick}
+            aria-label="Copy message body"
+            title="Copy message body"
+          >
+            <span className="material-icons-round text-sm" aria-hidden="true">
+              content_copy
+            </span>
+          </button>
           <button
             type="button"
             className={cx(

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
+import { buildFullMessageJson } from '../../lib/messageJson';
 import { cx } from '../../lib/cx';
 import { tryFormatJsonBody } from '../../lib/jsonFormatting';
+import type { ReceivedMessageDto } from '../../types/serviceBus';
 
 interface JsonMessageBodyProps {
   body: string;
+  fullMessage?: ReceivedMessageDto;
   className?: string;
 }
 
-export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
+const iconButtonClassName =
+  'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800';
+
+export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
   const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [fullCopyStatus, setFullCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
@@ -30,18 +37,47 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
     };
   }, [copyStatus]);
 
-  const handleCopyClick = async () => {
+  useEffect(() => {
+    if (fullCopyStatus === 'idle') {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setFullCopyStatus('idle');
+    }, 2000);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [fullCopyStatus]);
+
+  const copyText = async (
+    text: string,
+    setCopyStatus: (status: 'copied' | 'failed') => void,
+  ): Promise<void> => {
     if (!navigator.clipboard?.writeText) {
       setCopyStatus('failed');
       return;
     }
 
     try {
-      await navigator.clipboard.writeText(body);
+      await navigator.clipboard.writeText(text);
       setCopyStatus('copied');
     } catch {
       setCopyStatus('failed');
     }
+  };
+
+  const handleCopyClick = async () => {
+    await copyText(body, setCopyStatus);
+  };
+
+  const handleFullCopyClick = async () => {
+    if (!fullMessage) {
+      return;
+    }
+
+    await copyText(buildFullMessageJson(fullMessage), setFullCopyStatus);
   };
 
   return (
@@ -67,7 +103,7 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
           </span>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+            className={iconButtonClassName}
             onClick={handleCopyClick}
             aria-label="Copy message body"
             title="Copy message body"
@@ -76,6 +112,35 @@ export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
               content_copy
             </span>
           </button>
+          {fullMessage ? (
+            <>
+              <button
+                type="button"
+                className={iconButtonClassName}
+                onClick={handleFullCopyClick}
+                aria-label="Copy full message as JSON"
+                title="Copy full message as JSON"
+              >
+                <span className="material-icons-round text-sm" aria-hidden="true">
+                  data_object
+                </span>
+              </button>
+              <span
+                aria-live="polite"
+                className={cx(
+                  'text-[11px] font-medium',
+                  fullCopyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
+                  fullCopyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
+                )}
+              >
+                {fullCopyStatus === 'copied'
+                  ? 'Copied JSON'
+                  : fullCopyStatus === 'failed'
+                    ? 'Copy failed'
+                    : null}
+              </span>
+            </>
+          ) : null}
           <button
             type="button"
             className={cx(

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -10,14 +10,15 @@ interface JsonMessageBodyProps {
   className?: string;
 }
 
+type CopyStatus = 'idle' | 'copied' | 'copied-json' | 'failed';
+
 const iconButtonClassName =
   'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800';
 
 export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
-  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
-  const [fullCopyStatus, setFullCopyStatus] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
@@ -37,24 +38,7 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
     };
   }, [copyStatus]);
 
-  useEffect(() => {
-    if (fullCopyStatus === 'idle') {
-      return undefined;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setFullCopyStatus('idle');
-    }, 2000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [fullCopyStatus]);
-
-  const copyText = async (
-    text: string,
-    setCopyStatus: (status: 'copied' | 'failed') => void,
-  ): Promise<void> => {
+  const copyText = async (text: string, successStatus: 'copied' | 'copied-json'): Promise<void> => {
     if (!navigator.clipboard?.writeText) {
       setCopyStatus('failed');
       return;
@@ -62,14 +46,14 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
 
     try {
       await navigator.clipboard.writeText(text);
-      setCopyStatus('copied');
+      setCopyStatus(successStatus);
     } catch {
       setCopyStatus('failed');
     }
   };
 
   const handleCopyClick = async () => {
-    await copyText(body, setCopyStatus);
+    await copyText(body, 'copied');
   };
 
   const handleFullCopyClick = async () => {
@@ -77,7 +61,7 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
       return;
     }
 
-    await copyText(buildFullMessageJson(fullMessage), setFullCopyStatus);
+    await copyText(buildFullMessageJson(fullMessage), 'copied-json');
   };
 
   return (
@@ -91,15 +75,18 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
             aria-live="polite"
             className={cx(
               'text-[11px] font-medium',
-              copyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
+              (copyStatus === 'copied' || copyStatus === 'copied-json') &&
+                'text-emerald-600 dark:text-emerald-400',
               copyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
             )}
           >
             {copyStatus === 'copied'
               ? 'Copied'
-              : copyStatus === 'failed'
-                ? 'Copy failed'
-                : null}
+              : copyStatus === 'copied-json'
+                ? 'Copied JSON'
+                : copyStatus === 'failed'
+                  ? 'Copy failed'
+                  : null}
           </span>
           <button
             type="button"
@@ -113,33 +100,17 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
             </span>
           </button>
           {fullMessage ? (
-            <>
-              <button
-                type="button"
-                className={iconButtonClassName}
-                onClick={handleFullCopyClick}
-                aria-label="Copy full message as JSON"
-                title="Copy full message as JSON"
-              >
-                <span className="material-icons-round text-sm" aria-hidden="true">
-                  data_object
-                </span>
-              </button>
-              <span
-                aria-live="polite"
-                className={cx(
-                  'text-[11px] font-medium',
-                  fullCopyStatus === 'copied' && 'text-emerald-600 dark:text-emerald-400',
-                  fullCopyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
-                )}
-              >
-                {fullCopyStatus === 'copied'
-                  ? 'Copied JSON'
-                  : fullCopyStatus === 'failed'
-                    ? 'Copy failed'
-                    : null}
+            <button
+              type="button"
+              className={iconButtonClassName}
+              onClick={handleFullCopyClick}
+              aria-label="Copy full message as JSON"
+              title="Copy full message as JSON"
+            >
+              <span className="material-icons-round text-sm" aria-hidden="true">
+                data_object
               </span>
-            </>
+            </button>
           ) : null}
           <button
             type="button"

--- a/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
+++ b/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
@@ -1,13 +1,8 @@
-import {
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type ChangeEvent,
-	type FormEvent,
-} from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { serviceBusApi } from '../../api/serviceBusApi';
 import { useStoredBoolean } from '../../hooks/useStoredBoolean';
 import { cx } from '../../lib/cx';
+import { parseSendWindowJson } from '../../lib/sendWindowJsonImport';
 import type {
 	ApplicationPropertyInputDto,
 	ApplicationPropertyType,
@@ -50,6 +45,8 @@ interface SendMessageFormProps {
 	canSend: boolean;
 	isSubmitting: boolean;
 	requiresSession: boolean;
+	entityName: string | null;
+	topicName: string | null;
 	onSubmit: (request: SendMessageRequestDto) => Promise<void>;
 	onValidationError: (messages: string[]) => void;
 }
@@ -67,10 +64,19 @@ function createProperty(): ApplicationPropertyInputDto {
 	return { key: '', type: 'String', value: '' };
 }
 
+const messageIdFieldClasses =
+	'block w-full rounded-xl border bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20';
+const messageIdFieldNormalClasses =
+	'border-slate-200 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:focus:border-brand-400';
+const messageIdFieldWarningClasses =
+	'border-amber-400 bg-amber-50/60 focus:border-amber-500 focus:ring-2 focus:ring-amber-500/20 dark:border-amber-600/70 dark:bg-amber-950/20 dark:focus:border-amber-500';
+
 export function SendMessageForm({
 	canSend,
 	isSubmitting,
 	requiresSession,
+	entityName,
+	topicName,
 	onSubmit,
 	onValidationError,
 }: SendMessageFormProps) {
@@ -84,6 +90,97 @@ export function SendMessageForm({
 	const [isContentTypeMenuOpen, setIsContentTypeMenuOpen] = useState(false);
 	const [contentTypeFilter, setContentTypeFilter] = useState('');
 	const contentTypeContainerRef = useRef<HTMLDivElement | null>(null);
+	const [duplicateDetection, setDuplicateDetection] = useState<boolean | null>(null);
+	const [loadJsonStatus, setLoadJsonStatus] = useState<{
+		kind: 'error';
+		message: string;
+	} | null>(null);
+	const [loadJsonStatusFading, setLoadJsonStatusFading] = useState(false);
+	const loadJsonStatusTimerRef = useRef<number | null>(null);
+	const loadJsonFadeTimerRef = useRef<number | null>(null);
+	const [duplicateDetectionArmed, setDuplicateDetectionArmed] = useState(false);
+
+	const clearLoadJsonStatusTimers = () => {
+		if (loadJsonStatusTimerRef.current !== null) {
+			window.clearTimeout(loadJsonStatusTimerRef.current);
+			loadJsonStatusTimerRef.current = null;
+		}
+		if (loadJsonFadeTimerRef.current !== null) {
+			window.clearTimeout(loadJsonFadeTimerRef.current);
+			loadJsonFadeTimerRef.current = null;
+		}
+	};
+
+	const clearLoadJsonStatus = () => {
+		clearLoadJsonStatusTimers();
+		setLoadJsonStatus(null);
+		setLoadJsonStatusFading(false);
+	};
+
+	const showLoadJsonError = (message: string) => {
+		clearLoadJsonStatusTimers();
+		setLoadJsonStatus({ kind: 'error', message });
+		setLoadJsonStatusFading(false);
+		loadJsonStatusTimerRef.current = window.setTimeout(() => {
+			loadJsonStatusTimerRef.current = null;
+			setLoadJsonStatusFading(true);
+			loadJsonFadeTimerRef.current = window.setTimeout(() => {
+				loadJsonFadeTimerRef.current = null;
+				setLoadJsonStatus(null);
+				setLoadJsonStatusFading(false);
+			}, 500);
+		}, 5000);
+	};
+
+	useEffect(() => clearLoadJsonStatusTimers, []);
+
+	const duplicateDetectionWarning = duplicateDetection === true && duplicateDetectionArmed;
+
+	const messageIdValueRef = useRef(messageProperties.messageId);
+
+	useEffect(() => {
+		messageIdValueRef.current = messageProperties.messageId;
+	}, [messageProperties.messageId]);
+
+	useEffect(() => {
+		if (duplicateDetection === true && messageIdValueRef.current.length > 0) {
+			setDuplicateDetectionArmed(true);
+		}
+	}, [duplicateDetection]);
+
+	useEffect(() => {
+		setDuplicateDetectionArmed(false);
+		setDuplicateDetection(null);
+
+		const detailsType = topicName ? 'Topic' : 'Queue';
+		const detailsName = topicName ?? entityName;
+		if (!detailsName) {
+			return;
+		}
+
+		let isDisposed = false;
+		void serviceBusApi
+			.getEntityDetails(detailsType, detailsName, null)
+			.then((details) => {
+				if (isDisposed || details.properties === null) {
+					return;
+				}
+				const requiresDuplicate =
+					'requiresDuplicateDetection' in details.properties
+						? Boolean(details.properties.requiresDuplicateDetection)
+						: false;
+				setDuplicateDetection(requiresDuplicate);
+			})
+			.catch(() => {
+				if (!isDisposed) {
+					setDuplicateDetection(null);
+				}
+			});
+
+		return () => {
+			isDisposed = true;
+		};
+	}, [entityName, topicName]);
 
 	useEffect(() => {
 		if (!isContentTypeMenuOpen) {
@@ -158,6 +255,8 @@ export function SendMessageForm({
 		setApplicationProperties([]);
 		setIsContentTypeMenuOpen(false);
 		setContentTypeFilter('');
+		clearLoadJsonStatus();
+		// A successful send is the warning reset: do not re-arm here.
 	};
 
 	const handlePropertiesChange = (
@@ -173,6 +272,9 @@ export function SendMessageForm({
 			setContentTypeFilter(value);
 			setIsContentTypeMenuOpen(true);
 		}
+		if (key === 'messageId' && duplicateDetectionWarning) {
+			setDuplicateDetectionArmed(false);
+		}
 	};
 
 	const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -183,15 +285,66 @@ export function SendMessageForm({
 			return;
 		}
 
-		await onSubmit({
-			sendMessageApplicationProperties: applicationProperties,
-			sendMessageBody: messageBody,
-			sendMessageProperties: {
-				...messageProperties,
-				scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
-			},
-		});
+		clearLoadJsonStatus();
+
+		try {
+			await onSubmit({
+				sendMessageApplicationProperties: applicationProperties,
+				sendMessageBody: messageBody,
+				sendMessageProperties: {
+					...messageProperties,
+					scheduledEnqueueTime: messageProperties.scheduledEnqueueTime || null,
+				},
+			});
+		} catch {
+			return;
+		}
+
+		setDuplicateDetectionArmed(false);
 		resetForm();
+	};
+
+	const handleLoadJson = async () => {
+		clearLoadJsonStatus();
+		let pastedText: string;
+		try {
+			pastedText = await navigator.clipboard.readText();
+		} catch {
+			showLoadJsonError(
+				'Clipboard access was blocked. Allow clipboard access and try again, or paste the JSON into the payload manually.',
+			);
+			return;
+		}
+
+		if (pastedText.length === 0) {
+			showLoadJsonError('The clipboard is empty. Copy a full message as JSON first.');
+			return;
+		}
+
+		const result = parseSendWindowJson(pastedText);
+		if (!result.ok) {
+			showLoadJsonError(result.error);
+			return;
+		}
+
+		if (result.value.body !== null) {
+			setMessageBody(result.value.body);
+		}
+
+		const importedProperties = result.value.properties;
+		if (importedProperties && Object.keys(importedProperties).length > 0) {
+			setMessageProperties((current) => ({ ...current, ...importedProperties }));
+		}
+
+		const importedApplicationProperties = result.value.applicationProperties;
+		if (importedApplicationProperties) {
+			setApplicationProperties(importedApplicationProperties);
+		}
+
+		const pastedMessageId = result.value.properties?.messageId;
+		if (duplicateDetection === true && pastedMessageId !== undefined && pastedMessageId.length > 0) {
+			setDuplicateDetectionArmed(true);
+		}
 	};
 
 	return (
@@ -200,16 +353,42 @@ export function SendMessageForm({
 				<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
 					Send Message
 				</h2>
-				<button
-					type="button"
-					className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
-					onClick={() => setIsOpen((current) => !current)}
-				>
-					<span className="material-icons-round text-sm">
-						{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
-					</span>
-					<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
-				</button>
+				<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+					{isOpen && loadJsonStatus ? (
+						<span
+							role="alert"
+							className={cx(
+								'max-w-full truncate text-xs font-medium text-rose-700 transition-opacity duration-500 dark:text-rose-300',
+								loadJsonStatusFading && 'opacity-0',
+							)}
+						>
+							{loadJsonStatus.message}
+						</span>
+					) : null}
+					<button
+						type="button"
+						disabled={!isOpen}
+						className={cx(
+							'inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-500 transition hover:border-slate-300 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:text-white',
+							!isOpen && 'cursor-not-allowed opacity-40 hover:border-slate-200 hover:text-slate-500 dark:hover:border-slate-800 dark:hover:text-slate-300',
+						)}
+						onClick={() => void handleLoadJson()}
+						title="Paste the full message JSON from the clipboard into this form"
+					>
+						<span className="material-icons-round text-sm">content_paste</span>
+						Paste From Clipboard
+					</button>
+					<button
+						type="button"
+						className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
+						onClick={() => setIsOpen((current) => !current)}
+					>
+						<span className="material-icons-round text-sm">
+							{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+						</span>
+						<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
+					</button>
+				</div>
 			</div>
 
 			<div className={cx('send-form-transition', !isOpen && 'js-send-form-hidden')}>
@@ -229,17 +408,33 @@ export function SendMessageForm({
 
 						<div className="space-y-4">
 							<div>
-								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+								<label className="mb-2 flex items-center justify-between pr-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 									Message ID
+									{duplicateDetectionWarning ? (
+										<span
+											id="messageIdDuplicateDetectionWarning"
+											className="flex items-center gap-1 normal-case tracking-normal text-xs font-medium text-amber-700 dark:text-amber-400"
+										>
+											<span className="material-icons-round text-sm" aria-hidden="true">warning_amber</span>
+											<span>Duplicate detection enabled</span>
+										</span>
+									) : null}
 								</label>
 								<input
 									type="text"
 									maxLength={128}
-									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
-									value={messageProperties.messageId}
-									onChange={(event) => handlePropertiesChange('messageId', event)}
-								/>
-							</div>
+									aria-invalid={duplicateDetectionWarning || undefined}
+									aria-describedby={duplicateDetectionWarning ? 'messageIdDuplicateDetectionWarning' : undefined}
+									className={cx(
+										messageIdFieldClasses,
+										duplicateDetectionWarning
+											? messageIdFieldWarningClasses
+											: messageIdFieldNormalClasses,
+									)}
+								value={messageProperties.messageId}
+								onChange={(event) => handlePropertiesChange('messageId', event)}
+							/>
+						</div>
 
 							<div>
 								<label className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -380,7 +575,7 @@ export function SendMessageForm({
 					</div>
 
 					<div className="mt-6">
-						<div className="mb-3 flex items-center justify-between gap-3">
+						<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
 							<div>
 								<label className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 									Application Properties
@@ -389,23 +584,25 @@ export function SendMessageForm({
 									Optional typed key-value metadata to attach to the outgoing message.
 								</p>
 							</div>
-							<button
-								type="button"
-								className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
-								onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
-							>
-								<svg
-									className="h-4 w-4"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="1.8"
-									aria-hidden="true"
+							<div className="flex flex-wrap items-center gap-2">
+								<button
+									type="button"
+									className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800"
+									onClick={() => setApplicationProperties((current) => [...current, createProperty()])}
 								>
-									<path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
-								</svg>
-								Add Property
-							</button>
+									<svg
+										className="h-4 w-4"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										strokeWidth="1.8"
+										aria-hidden="true"
+									>
+										<path strokeLinecap="round" strokeLinejoin="round" d="M12 5v14M5 12h14" />
+									</svg>
+									Add Property
+								</button>
+							</div>
 						</div>
 
 						<div className="space-y-3">

--- a/src/ServiceBusViewer.Web/src/lib/messageJson.ts
+++ b/src/ServiceBusViewer.Web/src/lib/messageJson.ts
@@ -1,0 +1,13 @@
+import type { ReceivedMessageDto } from '../types/serviceBus';
+
+export function buildFullMessageJson(message: ReceivedMessageDto): string {
+	return JSON.stringify(
+		{
+			body: message.body,
+			properties: message.properties,
+			applicationProperties: message.applicationProperties,
+		},
+		undefined,
+		2,
+	);
+}

--- a/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
+++ b/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
@@ -1,0 +1,204 @@
+import type {
+	ApplicationPropertyInputDto,
+	ApplicationPropertyType,
+	SendMessagePropertiesDto,
+} from '../types/serviceBus';
+
+const applicationPropertyTypeNames: ReadonlySet<string> = new Set([
+	'String',
+	'Bool',
+	'Byte',
+	'ByteArray',
+	'SByte',
+	'Short',
+	'UShort',
+	'Int',
+	'UInt',
+	'Long',
+	'ULong',
+	'Float',
+	'Double',
+	'Decimal',
+	'Char',
+	'Guid',
+	'DateTime',
+	'DateTimeOffset',
+	'TimeSpan',
+	'Null',
+	'Unknown',
+]);
+
+const supportedPropertyKeys = [
+	'messageId',
+	'sessionId',
+	'correlationId',
+	'contentType',
+	'scheduledEnqueueTime',
+	'timeToLive',
+] as const satisfies readonly (keyof SendMessagePropertiesDto)[];
+
+export type SendWindowJsonImport = {
+	body: string | null;
+	properties: Partial<SendMessagePropertiesDto> | null;
+	applicationProperties: ApplicationPropertyInputDto[] | null;
+};
+
+export type SendWindowJsonImportResult =
+	| { ok: true; value: SendWindowJsonImport }
+	| { ok: false; error: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function toSendValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return '';
+	}
+
+	if (typeof value === 'string' || typeof value === 'boolean') {
+		return String(value);
+	}
+
+	if (typeof value === 'number') {
+		return Number.isFinite(value) ? String(value) : JSON.stringify(value);
+	}
+
+	if (typeof value === 'bigint') {
+		return value.toString();
+	}
+
+	return JSON.stringify(value);
+}
+
+function toDatetimeLocalValue(iso: string): string {
+	const date = new Date(iso);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	const pad = (component: number) => String(component).padStart(2, '0');
+	return [
+		`${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`,
+		`${pad(date.getHours())}:${pad(date.getMinutes())}`,
+	].join('T');
+}
+
+function parseStringProperty(
+	properties: Record<string, unknown>,
+	key: (typeof supportedPropertyKeys)[number],
+): string | undefined {
+	if (!(key in properties)) {
+		return undefined;
+	}
+
+	const raw = properties[key];
+	if (raw === null || raw === undefined) {
+		return '';
+	}
+
+	if (typeof raw !== 'string') {
+		throw new Error(`Property '${key}' must be a string.`);
+	}
+
+	if (key === 'scheduledEnqueueTime') {
+		return toDatetimeLocalValue(raw);
+	}
+
+	return raw;
+}
+
+function parseApplicationProperties(
+	raw: Record<string, unknown> | null,
+): ApplicationPropertyInputDto[] {
+	if (raw === null) {
+		return [];
+	}
+
+	const rows: ApplicationPropertyInputDto[] = [];
+	for (const [key, entry] of Object.entries(raw)) {
+		if (!isRecord(entry) || !('value' in entry)) {
+			throw new Error(`Application property '${key}' must be an object with a value.`);
+		}
+
+		const type = entry.type;
+		if (typeof type !== 'string' || !applicationPropertyTypeNames.has(type)) {
+			throw new Error(`Application property '${key}' has an unsupported type.`);
+		}
+
+		rows.push({
+			key,
+			type: type as ApplicationPropertyType,
+			value: toSendValue(entry['value']),
+		});
+	}
+
+	return rows;
+}
+
+export function parseSendWindowJson(text: string): SendWindowJsonImportResult {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return { ok: false, error: 'The clipboard text is not valid JSON.' };
+	}
+
+	if (!isRecord(parsed)) {
+		return { ok: false, error: 'The pasted JSON must be an object with message fields.' };
+	}
+
+	try {
+		const value: SendWindowJsonImport = {
+			body: null,
+			properties: null,
+			applicationProperties: null,
+		};
+
+		if ('body' in parsed) {
+			if (typeof parsed.body !== 'string') {
+				throw new Error("The 'body' field must be a string.");
+			}
+			value.body = parsed.body;
+		}
+
+		if ('properties' in parsed) {
+			const rawProperties = parsed.properties;
+			if (!isRecord(rawProperties)) {
+				throw new Error("'properties' must be an object.");
+			}
+
+			const patch: Partial<SendMessagePropertiesDto> = {};
+			let hasSupportedProperty = false;
+			for (const key of supportedPropertyKeys) {
+				const mapped = parseStringProperty(rawProperties, key);
+				if (mapped !== undefined) {
+					patch[key] = mapped;
+					hasSupportedProperty = true;
+				}
+			}
+			value.properties = hasSupportedProperty ? patch : {};
+		}
+
+		if ('applicationProperties' in parsed) {
+			const rawApplicationProperties = parsed.applicationProperties;
+			if (rawApplicationProperties !== null && !isRecord(rawApplicationProperties)) {
+				throw new Error("'applicationProperties' must be an object or null.");
+			}
+			value.applicationProperties = parseApplicationProperties(
+				rawApplicationProperties === null ? null : rawApplicationProperties,
+			);
+		}
+
+		return { ok: true, value };
+	} catch (error: unknown) {
+		const message =
+			error instanceof Error ? error.message : 'The pasted JSON does not match the expected message format.';
+		return { ok: false, error: message };
+	}
+}

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -20,6 +20,7 @@ import { getErrorMessages } from '../lib/problemDetails';
 import { useAppState } from '../state/AppStateContext';
 import type {
 	EntityIdDto,
+	ReceivedMessageApplicationPropertyDto,
 	SendMessageRequestDto,
 	ViewerState,
 } from '../types/serviceBus';
@@ -202,7 +203,7 @@ export function ViewerPage() {
 	};
 
 	const renderApplicationPropertiesTable = (
-		applicationProperties: Record<string, unknown> | null,
+		applicationProperties: Record<string, ReceivedMessageApplicationPropertyDto> | null,
 		emptyClassName: string,
 	) => {
 		if (applicationProperties && Object.keys(applicationProperties).length > 0) {
@@ -213,16 +214,20 @@ export function ViewerPage() {
 							<tr>
 								<th className="px-4 py-2 text-left font-medium">Application Property</th>
 								<th className="px-4 py-2 text-left font-medium">Value</th>
+								<th className="px-4 py-2 text-left font-medium">Type</th>
 							</tr>
 						</thead>
 						<tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-							{Object.entries(applicationProperties).map(([key, value]) => (
+							{Object.entries(applicationProperties).map(([key, property]) => (
 								<tr key={key}>
 									<td className="px-4 py-2 font-mono text-xs text-slate-700 dark:text-slate-200">
 										{key}
 									</td>
 									<td className="px-4 py-2 text-xs text-slate-600 dark:text-slate-300">
-										{formatUnknownValue(value)}
+										{formatUnknownValue(property.value)}
+									</td>
+									<td className="px-4 py-2 text-xs text-slate-600 dark:text-slate-300">
+										{property.type}
 									</td>
 								</tr>
 							))}

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -92,8 +92,10 @@ export function ViewerPage() {
 
 			try {
 				await work();
+				return true;
 			} catch (error: unknown) {
 				setErrorMessages(getErrorMessages(error));
+				return false;
 			} finally {
 				setPendingAction(null);
 			}
@@ -180,7 +182,7 @@ export function ViewerPage() {
 	};
 
 	const handleSend = async (request: SendMessageRequestDto) => {
-		await runAction('send', async () => {
+		const succeeded = await runAction('send', async () => {
 			await serviceBusApi.send(request);
 
 			if (currentViewer) {
@@ -200,6 +202,9 @@ export function ViewerPage() {
 				]);
 			}
 		});
+		if (!succeeded) {
+			throw new Error('The message was not sent.');
+		}
 	};
 
 	const renderApplicationPropertiesTable = (
@@ -352,13 +357,15 @@ export function ViewerPage() {
 								tone="success"
 							/>
 
-							<SendMessageForm
-								canSend={Boolean(currentViewer?.entityName)}
-								isSubmitting={pendingAction === 'send'}
-								requiresSession={Boolean(currentViewer?.requiresSession)}
-								onSubmit={handleSend}
-								onValidationError={setErrorMessages}
-							/>
+						<SendMessageForm
+							canSend={Boolean(currentViewer?.entityName)}
+							entityName={currentViewer?.entityName ?? null}
+							isSubmitting={pendingAction === 'send'}
+							requiresSession={Boolean(currentViewer?.requiresSession)}
+							topicName={currentViewer?.topicName ?? null}
+							onSubmit={handleSend}
+							onValidationError={setErrorMessages}
+						/>
 
 							<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
 								<div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/40">

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -439,7 +439,11 @@ export function ViewerPage() {
 												</div>
 											</div>
 
-											<JsonMessageBody body={currentViewer.displayedMessage.body} className="mt-6" />
+											<JsonMessageBody
+												body={currentViewer.displayedMessage.body}
+												fullMessage={currentViewer.displayedMessage}
+												className="mt-6"
+											/>
 										</>
 									) : (
 										<div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 px-4 py-8 text-center text-sm text-slate-500 dark:border-slate-700 dark:bg-slate-950/50 dark:text-slate-400">
@@ -555,7 +559,11 @@ export function ViewerPage() {
 																			</div>
 																		</div>
 
-																		<JsonMessageBody body={message.body} className="mt-4" />
+																		<JsonMessageBody
+																			body={message.body}
+																			fullMessage={message}
+																			className="mt-4"
+																		/>
 																	</td>
 																</tr>
 															) : null}

--- a/src/ServiceBusViewer.Web/src/types/serviceBus.ts
+++ b/src/ServiceBusViewer.Web/src/types/serviceBus.ts
@@ -24,10 +24,15 @@ export interface ReceivedMessagePropertiesDto {
 	timeToLive: string | null;
 }
 
+export interface ReceivedMessageApplicationPropertyDto {
+	value: unknown;
+	type: ApplicationPropertyType;
+}
+
 export interface ReceivedMessageDto {
 	body: string;
 	properties: ReceivedMessagePropertiesDto;
-	applicationProperties: Record<string, unknown> | null;
+	applicationProperties: Record<string, ReceivedMessageApplicationPropertyDto> | null;
 }
 
 export interface ViewerState {
@@ -67,6 +72,7 @@ export type ApplicationPropertyType =
 	| 'String'
 	| 'Bool'
 	| 'Byte'
+	| 'ByteArray'
 	| 'SByte'
 	| 'Short'
 	| 'UShort'
@@ -81,7 +87,9 @@ export type ApplicationPropertyType =
 	| 'Guid'
 	| 'DateTime'
 	| 'DateTimeOffset'
-	| 'TimeSpan';
+	| 'TimeSpan'
+	| 'Null'
+	| 'Unknown';
 
 export interface ApplicationPropertyInputDto {
 	key: string;

--- a/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
+++ b/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
@@ -1,6 +1,7 @@
 namespace ServiceBusViewer.Api.Converters;
 
 using System.Globalization;
+using ApiApplicationPropertyType = ServiceBusViewer.Api.Models.ApplicationPropertyType;
 
 /// <summary>Provides value normalization helpers for API responses.</summary>
 internal static class ResponseMapping
@@ -17,5 +18,33 @@ internal static class ResponseMapping
 			char character => character.ToString(),
 			byte[] bytes => Convert.ToBase64String(bytes),
 			_ => value
+		};
+
+	/// <summary>Gets the serialized application-property type for a supported value.</summary>
+	/// <param name="value">The application-property value.</param>
+	/// <returns>The serialized application-property type.</returns>
+	internal static ApiApplicationPropertyType GetApplicationPropertyType(object? value)
+		=> value switch {
+			string => ApiApplicationPropertyType.String,
+			bool => ApiApplicationPropertyType.Bool,
+			byte => ApiApplicationPropertyType.Byte,
+			byte[] => ApiApplicationPropertyType.ByteArray,
+			sbyte => ApiApplicationPropertyType.SByte,
+			short => ApiApplicationPropertyType.Short,
+			ushort => ApiApplicationPropertyType.UShort,
+			int => ApiApplicationPropertyType.Int,
+			uint => ApiApplicationPropertyType.UInt,
+			long => ApiApplicationPropertyType.Long,
+			ulong => ApiApplicationPropertyType.ULong,
+			float => ApiApplicationPropertyType.Float,
+			double => ApiApplicationPropertyType.Double,
+			decimal => ApiApplicationPropertyType.Decimal,
+			char => ApiApplicationPropertyType.Char,
+			Guid => ApiApplicationPropertyType.Guid,
+			DateTime => ApiApplicationPropertyType.DateTime,
+			DateTimeOffset => ApiApplicationPropertyType.DateTimeOffset,
+			TimeSpan => ApiApplicationPropertyType.TimeSpan,
+			null => ApiApplicationPropertyType.Null,
+			_ => ApiApplicationPropertyType.Unknown
 		};
 }

--- a/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
+++ b/src/ServiceBusViewer/Api/Converters/ResponseMapping.cs
@@ -17,6 +17,12 @@ internal static class ResponseMapping
 			Guid guid => guid.ToString(),
 			char character => character.ToString(),
 			byte[] bytes => Convert.ToBase64String(bytes),
+
+			// Preserve values that may exceed JavaScript's safe numeric precision so client-side JSON export remains exact.
+			long number => number.ToString(CultureInfo.InvariantCulture),
+			ulong number => number.ToString(CultureInfo.InvariantCulture),
+			decimal number => number.ToString(CultureInfo.InvariantCulture),
+
 			_ => value
 		};
 

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectRequest.cs
@@ -12,14 +12,19 @@ using System.Collections.Generic;
 /// <paramref name="SubscriptionName"/> is also provided, in which case it identifies the parent topic.
 /// </param>
 /// <param name="SubscriptionName">Optional subscription name for direct access through its parent topic.</param>
-internal sealed record ConnectRequest(
+public sealed record ConnectRequest(
 	string ConnectionString,
 	string? EmulatorManagementConnectionString,
 	string? QueueOrTopicName,
 	string? SubscriptionName);
 
+/// <summary>Validator for <see cref="ConnectRequest"/>.</summary>
 internal static class ConnectRequestValidator
 {
+	/// <summary>Validates a <see cref="ConnectRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="ConnectRequest"/> instance to validate.</param>
+	/// <param name="errors">A dictionary to receive validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(ConnectRequest request, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		var local = new Dictionary<string, string[]>(capacity: 1);

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Connect/ConnectResponse.cs
@@ -16,7 +16,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id used for receive or null.</param>
-internal sealed record ConnectResponse(
+public sealed record ConnectResponse(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Endpoints/Connection/Disconnect/DisconnectResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Connection/Disconnect/DisconnectResponse.cs
@@ -9,7 +9,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="Connection">Connection settings snapshot.</param>
 /// <param name="Viewer">Current viewer state or null.</param>
 /// <param name="IsConnected">Whether the viewer is currently connected.</param>
-internal sealed record DisconnectResponse(
+public sealed record DisconnectResponse(
 	string ApplicationVersion,
 	ConnectionSettings Connection,
 	ViewerState? Viewer,

--- a/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsRequest.cs
@@ -2,16 +2,22 @@ namespace ServiceBusViewer.Api.Endpoints.Entities.Details;
 
 using System.Collections.Generic;
 
-/// <summary>
-/// Request parameters for retrieving entity details.
-/// </summary>
-internal sealed record DetailsRequest(
+/// <summary>Request parameters for retrieving entity details.</summary>
+/// <param name="Type">The type of the entity.</param>
+/// <param name="Name">The name of the entity.</param>
+/// <param name="TopicName">The name of the topic, if applicable.</param>
+public sealed record DetailsRequest(
 	string Type,
 	string Name,
 	string? TopicName);
 
+/// <summary>Validator for <see cref="DetailsRequest"/>.</summary>
 internal static class DetailsRequestValidator
 {
+	/// <summary>Validates a <see cref="DetailsRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="DetailsRequest"/> instance to validate.</param>
+	/// <param name="errors">A dictionary to receive validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(DetailsRequest request, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		Dictionary<string, string[]> local = new();
@@ -24,8 +30,7 @@ internal static class DetailsRequestValidator
 		if (request.Type is not null && !IsSupportedEntityType(request.Type.AsSpan().Trim()))
 			local["type"] = [$"Unsupported entity type '{request.Type}'."];
 
-		if (request.Type?.Equals("Subscription", StringComparison.OrdinalIgnoreCase) is true
-			&& string.IsNullOrWhiteSpace(request.TopicName))
+		if (request.Type?.Equals("Subscription", StringComparison.OrdinalIgnoreCase) is true && string.IsNullOrWhiteSpace(request.TopicName))
 			local[nameof(request.TopicName)] = ["Topic name is required when selecting a subscription."];
 
 		if (local.Count > 0) { errors = local; return false; }

--- a/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Entities/Details/DetailsResponse.cs
@@ -12,7 +12,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="Name">Entity name.</param>
 /// <param name="TopicName">Topic name for subscriptions, otherwise null.</param>
 /// <param name="Properties">Entity properties when available.</param>
-internal sealed record DetailsResponse(
+public sealed record DetailsResponse(
 	string ServiceBusHostName,
 	bool IsManagementApiAvailable,
 	IReadOnlyList<EntityId> AvailableEntities,

--- a/src/ServiceBusViewer/Api/Endpoints/SessionState/GetSessionState/SessionStateResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/SessionState/GetSessionState/SessionStateResponse.cs
@@ -8,7 +8,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="Connection">Connection settings snapshot.</param>
 /// <param name="Viewer">Current viewer state or null.</param>
 /// <param name="IsConnected">Whether the viewer is currently connected.</param>
-internal sealed record SessionStateResponse(
+public sealed record SessionStateResponse(
 	string ApplicationVersion,
 	bool IsRunningInContainer,
 	ConnectionSettings Connection,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/GetViewer/GetViewerResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/GetViewer/GetViewerResponse.cs
@@ -16,7 +16,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id used for receive or null.</param>
-internal sealed record GetViewerResponse(
+public sealed record GetViewerResponse(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveRequest.cs
@@ -1,13 +1,12 @@
 namespace ServiceBusViewer.Api.Endpoints.Viewer.Receive;
 
 using System.Collections.Generic;
-using ServiceBusViewer.Api.Endpoints;
 
 /// <summary>
 /// Request to receive messages; optionally specifies a session id to receive from.
 /// </summary>
 /// <param name="ReceiveSessionId">Optional session id to receive from.</param>
-internal sealed record ReceiveRequest(string? ReceiveSessionId);
+public sealed record ReceiveRequest(string? ReceiveSessionId);
 
 internal static class ReceiveRequestValidator
 {

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Receive/ReceiveResponse.cs
@@ -16,7 +16,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id used for receive or null.</param>
-internal sealed record ReceiveResponse(
+public sealed record ReceiveResponse(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Refresh/RefreshResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Refresh/RefreshResponse.cs
@@ -16,7 +16,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id used for receive or null.</param>
-internal sealed record RefreshResponse(
+public sealed record RefreshResponse(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityRequest.cs
@@ -8,13 +8,18 @@ using System.Collections.Generic;
 /// <param name="SelectedEntityType">Type of entity to select ("Queue", "Topic", "Subscription").</param>
 /// <param name="SelectedEntityName">Name of the entity to select.</param>
 /// <param name="SelectedTopicName">Topic name when selecting a subscription.</param>
-internal sealed record SelectEntityRequest(
+public sealed record SelectEntityRequest(
 	string SelectedEntityType,
 	string SelectedEntityName,
 	string? SelectedTopicName);
 
+/// <summary>Validates a <see cref="SelectEntityRequest"/> instance.</summary>
 internal static class SelectEntityRequestValidator
 {
+	/// <summary>Validates a <see cref="SelectEntityRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="SelectEntityRequest"/> instance to validate.</param>
+	/// <param name="errors">A dictionary of validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(SelectEntityRequest request, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		Dictionary<string, string[]> local = new();
@@ -24,9 +29,8 @@ internal static class SelectEntityRequestValidator
 		if (string.IsNullOrWhiteSpace(request.SelectedEntityName))
 			local[nameof(request.SelectedEntityName)] = ["Entity name is required."];
 
-		if (local.Count > 0) { errors = local; return false; }
+		errors = local.Count > 0 ? local : null;
 
-		errors = null;
-		return true;
+		return errors is null;
 	}
 }

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityResponse.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/SelectEntity/SelectEntityResponse.cs
@@ -16,7 +16,7 @@ using ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id used for receive or null.</param>
-internal sealed record SelectEntityResponse(
+public sealed record SelectEntityResponse(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
@@ -15,8 +15,13 @@ public sealed record SendRequest(
 	SendMessagePropertiesRequest? SendMessageProperties,
 	IReadOnlyList<SendMessageApplicationPropertyRequest>? SendMessageApplicationProperties);
 
+/// <summary>Validates a <see cref="SendRequest"/> instance.</summary>
 internal static class SendRequestValidator
 {
+	/// <summary>Validates a <see cref="SendRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="SendRequest"/> instance to validate.</param>
+	/// <param name="errors">A dictionary of validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(SendRequest request, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		Dictionary<string, string[]> local = new();
@@ -46,10 +51,15 @@ public sealed record SendMessagePropertiesRequest(
 	string? ScheduledEnqueueTime,
 	string? TimeToLive);
 
+/// <summary>Validates a <see cref="SendMessagePropertiesRequest"/> instance.</summary>
 internal static class SendMessagePropertiesRequestValidator
 {
 	private const int _maxSystemPropertyLength = 128;
 
+	/// <summary>Validates a <see cref="SendMessagePropertiesRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="SendMessagePropertiesRequest"/> instance to validate.</param>
+	/// <param name="errors">A dictionary of validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(SendMessagePropertiesRequest? request, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		Dictionary<string, string[]> local = new();
@@ -90,8 +100,14 @@ public sealed record SendMessageApplicationPropertyRequest(
 	string? Value,
 	string? Type);
 
+/// <summary>Validates a <see cref="SendMessageApplicationPropertyRequest"/> instance.	</summary>
 internal static class SendMessageApplicationPropertyRequestValidator
 {
+	/// <summary>Validates a <see cref="SendMessageApplicationPropertyRequest"/> instance.</summary>
+	/// <param name="request">The <see cref="SendMessageApplicationPropertyRequest"/> instance to validate.</param>
+	/// <param name="fieldName">The field name for error reporting.</param>
+	/// <param name="errors">A dictionary of validation errors, if any.</param>
+	/// <returns><c>true</c> if the request is valid; otherwise, <c>false</c>.</returns>
 	public static bool Validate(SendMessageApplicationPropertyRequest request, string fieldName, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		var local = new Dictionary<string, string[]>();

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
@@ -10,7 +10,7 @@ using System.Globalization;
 /// <param name="SendMessageBody">Message body to send.</param>
 /// <param name="SendMessageProperties">Optional system properties for the message.</param>
 /// <param name="SendMessageApplicationProperties">Optional list of application properties.</param>
-internal sealed record SendRequest(
+public sealed record SendRequest(
 	string? SendMessageBody,
 	SendMessagePropertiesRequest? SendMessageProperties,
 	IReadOnlyList<SendMessageApplicationPropertyRequest>? SendMessageApplicationProperties);
@@ -23,13 +23,9 @@ internal static class SendRequestValidator
 		if (string.IsNullOrWhiteSpace(request.SendMessageBody))
 			local[nameof(request.SendMessageBody)] = ["Message body cannot be empty."];
 
-		if (local.Count > 0) {
-			errors = local;
-			return false;
-		}
+		errors = local.Count > 0 ? local : null;
 
-		errors = null;
-		return true;
+		return errors is null;
 	}
 }
 
@@ -42,7 +38,7 @@ internal static class SendRequestValidator
 /// <param name="ContentType">Content type.</param>
 /// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601) or null.</param>
 /// <param name="TimeToLive">Time-to-live string or null.</param>
-internal sealed record SendMessagePropertiesRequest(
+public sealed record SendMessagePropertiesRequest(
 	string? MessageId,
 	string? SessionId,
 	string? CorrelationId,
@@ -77,22 +73,19 @@ internal static class SendMessagePropertiesRequestValidator
 		if (!string.IsNullOrWhiteSpace(request.TimeToLive) && !TimeSpan.TryParse(request.TimeToLive, CultureInfo.InvariantCulture, out _))
 			local[nameof(SendMessagePropertiesRequest.TimeToLive)] = ["Time to live must be a valid time span value."];
 
-		if (local.Count > 0) {
-			errors = local;
-			return false;
-		}
+		errors = local.Count > 0 ? local : null;
 
-		errors = null;
-		return true;
+		return errors is null;
 	}
 }
+
 /// <summary>
 /// Single application property entry for a message to send.
 /// </summary>
 /// <param name="Key">Property key.</param>
 /// <param name="Value">Property value.</param>
 /// <param name="Type">Property type name.</param>
-internal sealed record SendMessageApplicationPropertyRequest(
+public sealed record SendMessageApplicationPropertyRequest(
 	string? Key,
 	string? Value,
 	string? Type);
@@ -102,11 +95,14 @@ internal static class SendMessageApplicationPropertyRequestValidator
 	public static bool Validate(SendMessageApplicationPropertyRequest request, string fieldName, out IReadOnlyDictionary<string, string[]>? errors)
 	{
 		var local = new Dictionary<string, string[]>();
+
 		if (string.IsNullOrWhiteSpace(request.Type))
 			local[fieldName] = ["Application property type is required."];
+
 		// enum parsing and type-specific validation remains in the handler helper where the ApplicationProperty instance is constructed.
-		if (local.Count > 0) { errors = local; return false; }
-		errors = null;
-		return true;
+
+		errors = local.Count > 0 ? local : null;
+
+		return errors is null;
 	}
 }

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
@@ -75,6 +75,11 @@ internal static class SendRequestHandler
 				continue;
 			}
 
+			if (!IsSupportedSendApplicationPropertyType(propertyType)) {
+				errors[fieldName] = [$"Application property type '{property.Type}' is not supported for sending."];
+				continue;
+			}
+
 			properties.Add(new ApplicationProperty(
 				property.Key ?? string.Empty,
 				property.Value ?? string.Empty,
@@ -83,4 +88,9 @@ internal static class SendRequestHandler
 
 		return properties;
 	}
+
+	private static bool IsSupportedSendApplicationPropertyType(ApplicationPropertyType type)
+		=> type is not ApplicationPropertyType.ByteArray
+		   && type is not ApplicationPropertyType.Null
+		   && type is not ApplicationPropertyType.Unknown;
 }

--- a/src/ServiceBusViewer/Api/Models/ApplicationPropertyType.cs
+++ b/src/ServiceBusViewer/Api/Models/ApplicationPropertyType.cs
@@ -1,0 +1,32 @@
+namespace ServiceBusViewer.Api.Models;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+/// <summary>Serialized application property type values exposed by the API.</summary>
+[SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Member names are serialized application-property type values shared with the frontend.")]
+[JsonConverter(typeof(JsonStringEnumConverter<ApplicationPropertyType>))]
+public enum ApplicationPropertyType
+{
+	String = 1,
+	Bool,
+	Byte,
+	ByteArray,
+	SByte,
+	Short,
+	UShort,
+	Int,
+	UInt,
+	Long,
+	ULong,
+	Float,
+	Double,
+	Decimal,
+	Char,
+	Guid,
+	DateTime,
+	DateTimeOffset,
+	TimeSpan,
+	Null,
+	Unknown
+}

--- a/src/ServiceBusViewer/Api/Models/ConnectionSettings.cs
+++ b/src/ServiceBusViewer/Api/Models/ConnectionSettings.cs
@@ -8,7 +8,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <paramref name="SubscriptionName"/> is also provided, in which case it identifies the parent topic.
 /// </param>
 /// <param name="SubscriptionName">Optional subscription name for direct access through its parent topic.</param>
-internal sealed record ConnectionSettings(
+public sealed record ConnectionSettings(
 	string ConnectionString,
 	string? EmulatorManagementConnectionString,
 	string? QueueOrTopicName,

--- a/src/ServiceBusViewer/Api/Models/CorrelationSubscriptionRule.cs
+++ b/src/ServiceBusViewer/Api/Models/CorrelationSubscriptionRule.cs
@@ -12,7 +12,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="ContentType">Optional content type filter value.</param>
 /// <param name="ApplicationProperties">Application properties used by the correlation filter.</param>
 /// <param name="ActionExpression">Optional action expression applied by the rule.</param>
-internal sealed record CorrelationSubscriptionRule(
+public sealed record CorrelationSubscriptionRule(
 	string Name,
 	string? CorrelationId,
 	string? MessageId,

--- a/src/ServiceBusViewer/Api/Models/EntityId.cs
+++ b/src/ServiceBusViewer/Api/Models/EntityId.cs
@@ -8,13 +8,17 @@ using ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <param name="Type">Entity kind: "Queue", "Topic" or "Subscription".</param>
 /// <param name="Name">Entity name.</param>
 /// <param name="TopicName">Topic name for subscriptions; null for queues/topics.</param>
-internal sealed record EntityId(
+public sealed record EntityId(
 	string Type,
 	string Name,
 	string? TopicName);
 
+/// <summary>Extension methods for <see cref="EntityId"/>.</summary>
 internal static class EntityIdExtensions
 {
+	/// <summary>Converts a business layer <see cref="Business.Viewer.Contracts.ServiceBus.EntityId"/> to an API layer <see cref="EntityId"/>.</summary>
+	/// <param name="entity">The business layer entity identifier.</param>
+	/// <returns>The corresponding API layer entity identifier.</returns>
 	internal static EntityId ToApiModel(this Business.Viewer.Contracts.ServiceBus.EntityId entity)
 		=> entity switch {
 			QueueEntityId queue => new Models.EntityId("Queue", queue.Name, null),

--- a/src/ServiceBusViewer/Api/Models/EntityProperties.cs
+++ b/src/ServiceBusViewer/Api/Models/EntityProperties.cs
@@ -17,7 +17,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="EnablePartitioning">Whether partitioning is enabled.</param>
 /// <param name="AutoDeleteOnIdle">Auto-delete on idle as string or null.</param>
 /// <param name="Rules">Subscription rules if applicable.</param>
-internal sealed record EntityProperties(
+public sealed record EntityProperties(
 	string Kind,
 	string Name,
 	string? TopicName,

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
@@ -3,19 +3,17 @@ namespace ServiceBusViewer.Api.Models;
 using System.Globalization;
 using ServiceBusViewer.Api.Converters;
 
-/// <summary>
-/// Represents a received message body and its metadata.
-/// </summary>
+/// <summary>Represents a received message body and its metadata.</summary>
 /// <param name="Body">Message body as a string.</param>
 /// <param name="Properties">System properties of the received message.</param>
 /// <param name="ApplicationProperties">Application properties dictionary.</param>
-internal sealed record ReceivedMessage(
+public sealed record ReceivedMessage(
 	string Body,
 	ReceivedMessageProperties Properties,
-	IReadOnlyDictionary<string, object> ApplicationProperties);
+	IReadOnlyDictionary<string, ReceivedMessageApplicationProperty> ApplicationProperties);
 
 /// <summary>Provides mappings from business received-message models to API models.</summary>
-internal static class ReceivedMessageExtensions
+public static class ReceivedMessageExtensions
 {
 	/// <summary>Maps a business received message to its API representation.</summary>
 	/// <param name="message">The business received message to map.</param>
@@ -23,7 +21,7 @@ internal static class ReceivedMessageExtensions
 	internal static ReceivedMessage ToApiModel(this Business.Viewer.Contracts.ServiceBus.ReceivedMessage message)
 		=> new Models.ReceivedMessage(
 				message.Body,
-				new Models.ReceivedMessageProperties(
+				new ReceivedMessageProperties(
 					message.Properties.MessageId,
 					message.Properties.PartitionKey,
 					message.Properties.SessionId,
@@ -32,5 +30,15 @@ internal static class ReceivedMessageExtensions
 					message.Properties.EnqueuedTimeUtc.ToString("O", CultureInfo.InvariantCulture),
 					message.Properties.ScheduledEnqueueTime?.ToString("O", CultureInfo.InvariantCulture),
 					message.Properties.TimeToLive?.ToString("c", CultureInfo.InvariantCulture)),
-				message.ApplicationProperties.ToDictionary<KeyValuePair<string, object>, string, object>(pair => pair.Key, pair => ResponseMapping.NormalizeObjectValue(pair.Value) ?? string.Empty));
+				message.ApplicationProperties.ToDictionary<KeyValuePair<string, object>, string, ReceivedMessageApplicationProperty>(
+					pair => pair.Key,
+					pair => new ReceivedMessageApplicationProperty(
+						ResponseMapping.NormalizeObjectValue(pair.Value) ?? string.Empty,
+						ResponseMapping.GetApplicationPropertyType(pair.Value))));
 }
+
+
+/// <summary>Represents a received message application property value and its type metadata.</summary>
+/// <param name="Value">The normalized application property value.</param>
+/// <param name="Type">The original application property type name.</param>
+public sealed record ReceivedMessageApplicationProperty(object Value, ApplicationPropertyType Type);

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
@@ -11,7 +11,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="EnqueuedTimeUtc">Enqueued time in UTC (ISO-8601).</param>
 /// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601) or null.</param>
 /// <param name="TimeToLive">Time-to-live as string or null.</param>
-internal sealed record ReceivedMessageProperties(
+public sealed record ReceivedMessageProperties(
 	string MessageId,
 	string? PartitionKey,
 	string? SessionId,

--- a/src/ServiceBusViewer/Api/Models/SqlSubscriptionRule.cs
+++ b/src/ServiceBusViewer/Api/Models/SqlSubscriptionRule.cs
@@ -4,7 +4,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="Name">Rule name.</param>
 /// <param name="SqlExpression">SQL filter expression.</param>
 /// <param name="ActionExpression">Optional action expression applied by the rule.</param>
-internal sealed record SqlSubscriptionRule(
+public sealed record SqlSubscriptionRule(
 	string Name,
 	string SqlExpression,
 	string? ActionExpression) : SubscriptionRule(Name);

--- a/src/ServiceBusViewer/Api/Models/SubscriptionRule.cs
+++ b/src/ServiceBusViewer/Api/Models/SubscriptionRule.cs
@@ -2,4 +2,4 @@ namespace ServiceBusViewer.Api.Models;
 
 /// <summary>Base type for subscription rule responses.</summary>
 /// <param name="Name">Rule name.</param>
-internal abstract record SubscriptionRule(string Name);
+public abstract record SubscriptionRule(string Name);

--- a/src/ServiceBusViewer/Api/Models/UnknownSubscriptionRule.cs
+++ b/src/ServiceBusViewer/Api/Models/UnknownSubscriptionRule.cs
@@ -4,7 +4,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="Name">Rule name.</param>
 /// <param name="FilterTypeName">Runtime filter type name.</param>
 /// <param name="FilterExpression">Textual filter representation.</param>
-internal sealed record UnknownSubscriptionRule(
+public sealed record UnknownSubscriptionRule(
 	string Name,
 	string FilterTypeName,
 	string FilterExpression) : SubscriptionRule(Name);

--- a/src/ServiceBusViewer/Api/Models/ViewerState.cs
+++ b/src/ServiceBusViewer/Api/Models/ViewerState.cs
@@ -13,7 +13,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="DisplayedMessage">Currently selected/displayed message or null.</param>
 /// <param name="SendResultMessage">Result message from the last send operation or null.</param>
 /// <param name="ReceiveSessionId">Session id currently used for receive operations or null.</param>
-internal record ViewerState(
+public record ViewerState(
 	string ServiceBusHostName,
 	string? EntityName,
 	string? TopicName,
@@ -27,11 +27,15 @@ internal record ViewerState(
 	string? ReceiveSessionId);
 
 
+
+/// <summary>Extension methods for <see cref="ViewerState"/>.</summary>
 internal static class ViewerStateExtensions
 {
+	/// <summary>Converts a business model <see cref="Business.Viewer.Contracts.ViewerState"/> to an API model <see cref="ViewerState"/>.</summary>
+	/// <param name="state">The business model viewer state to convert.</param>
+	/// <returns>The converted API model viewer state.</returns>
 	internal static ViewerState ToApiModel(this Business.Viewer.Contracts.ViewerState state)
-	{
-		return new Models.ViewerState(
+		=> new ViewerState(
 			state.ServiceBusHostName,
 			state.EntityName,
 			state.TopicName,
@@ -43,5 +47,4 @@ internal static class ViewerStateExtensions
 			state.DisplayedMessage?.ToApiModel(),
 			state.SendResultMessage,
 			state.ReceiveSessionId);
-	}
 }

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ApplicationProperty.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ApplicationProperty.cs
@@ -9,6 +9,7 @@ public enum ApplicationPropertyType
 	String = 1,
 	Bool,
 	Byte,
+	ByteArray,
 	SByte,
 	Short,
 	UShort,
@@ -23,7 +24,9 @@ public enum ApplicationPropertyType
 	Guid,
 	DateTime,
 	DateTimeOffset,
-	TimeSpan
+	TimeSpan,
+	Null,
+	Unknown
 }
 
 /// <summary>Represents a single application property for an outgoing Service Bus message.</summary>

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -272,6 +272,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				ApplicationPropertyType.String => value,
 				ApplicationPropertyType.Bool => bool.Parse(value),
 				ApplicationPropertyType.Byte => byte.Parse(value, CultureInfo.InvariantCulture),
+				ApplicationPropertyType.ByteArray => throw new FormatException("ByteArray application properties are not supported for sending."),
 				ApplicationPropertyType.SByte => sbyte.Parse(value, CultureInfo.InvariantCulture),
 				ApplicationPropertyType.Short => short.Parse(value, CultureInfo.InvariantCulture),
 				ApplicationPropertyType.UShort => ushort.Parse(value, CultureInfo.InvariantCulture),
@@ -287,6 +288,8 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 				ApplicationPropertyType.DateTime => DateTime.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
 				ApplicationPropertyType.DateTimeOffset => DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind),
 				ApplicationPropertyType.TimeSpan => TimeSpan.Parse(value, CultureInfo.InvariantCulture),
+				ApplicationPropertyType.Null => throw new FormatException("Null application properties are not supported for sending."),
+				ApplicationPropertyType.Unknown => throw new FormatException("Unknown application property types are not supported for sending."),
 				_ => throw new ArgumentOutOfRangeException(nameof(type), type, "Unsupported application property type.")
 			};
 		}

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.43.0</Version>
+		<Version>0.45.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.42.0</Version>
+		<Version>0.43.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.41.0</Version>
+		<Version>0.42.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.40.5</Version>
+		<Version>0.41.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
### Summary
Promotes the v0.45.0 feature set to release: full-message JSON copy & paste round-trip, body copy, typed application property display, plus a numeric-precision fix and Aspire package updates.

### Added
- **Full-message JSON copy** — received and peeked messages can now be copied as valid JSON (body, system properties, application properties), alongside the existing body-only copy.
- **Full-message JSON paste** — the Send Message window accepts a full-message JSON payload, loading it into the payload editor, message properties, and application properties; only fields present in the JSON are updated.
- **Duplicate-detection warning** — warning indicator on the Message ID field when the selected queue/topic (parent topic of a selected subscription) has duplicate detection enabled and the pasted JSON carries a non-empty message ID. Resets on edit or successful send; a failed send keeps it.
- **Copy message body button** — copies the original message body text as plain text.
- **Application property types** — received and peeked message details now display each application property's type alongside its name and value.

### Fixed
- **Numeric precision** — numeric precision is now preserved in application properties.

### Chore
- Aspire SDK and package references updated to 13.5.0.