### PR TITLE
feat: add To, Reply To, Subject, and Partition Key fields to send window

### DIFF
--- a/.agents/skills/aspire-monitoring/SKILL.md
+++ b/.agents/skills/aspire-monitoring/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: aspire-monitoring
+description: >-
+  **ANALYSIS SKILL** - Observe Aspire apps: logs, traces, metrics, resource state,
+  telemetry export, browser telemetry, and the standalone dashboard. Routes between local
+  Aspire CLI, AKS workload diagnostics, and deployed Azure resource health.
+  USE FOR: aspire logs, aspire otel logs, aspire otel traces, aspire otel spans, aspire
+  describe, aspire ps, aspire export, aspire dashboard run, --include-hidden, browser logs
+  in dashboard, WithBrowserLogs, App Insights query, AKS pod logs, container app logs.
+  DO NOT USE FOR: start/stop/wait (use aspire-orchestration), deploy/publish/destroy (use
+  aspire-deployment), AppHost code edits like WithBrowserLogs() (use aspireify), Azure
+  provisioning (use azure-prepare).
+  INVOKES: aspire CLI, azure-diagnostics (deployed Azure), kubectl + Container Insights.
+  FOR SINGLE OPERATIONS: Run the aspire CLI command directly for quick log or describe lookups.
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.1"
+---
+
+# Aspire Monitoring
+
+> Aspire CLI provides full observability **locally**. For deployed apps, route to platform-specific tools.
+
+## Diagnostics Bridge — Where To Look
+
+| Need | Environment | Tool | Command / Route |
+|------|------------|------|-----------------|
+| Console logs | Local dev | Aspire CLI | `aspire logs <resource>` |
+| Structured logs | Local dev | Aspire CLI | `aspire otel logs [resource]` |
+| Distributed traces | Local dev | Aspire CLI | `aspire otel traces [resource]` |
+| Span detail | Local dev | Aspire CLI | `aspire otel spans [resource]` |
+| Resource state | Local dev | Aspire CLI | `aspire describe` (add `--include-hidden` if a resource is missing) |
+| Telemetry export | Local dev | Aspire CLI | `aspire export [resource]` |
+| Standalone dashboard | Any (no AppHost) | Aspire CLI | `aspire dashboard run` (foreground/blocking — see below) |
+| Browser console / network / screenshots | Local dev (frontend) | Aspire dashboard | Surfaced via `Aspire.Hosting.Browsers` + `WithBrowserLogs()` |
+| AppHost / deployment definition | Authoring | aspire-deployment skill | → `aspire-deployment` skill |
+| AKS workload (pod logs, pod state) | Deployed AKS | kubectl + Container Insights | `kubectl logs <pod>`, `kubectl describe pod <pod>`, Container Insights in Azure Monitor |
+| Azure resource health (App Insights, Front Door, NSP, private endpoint) | Deployed Azure | azure-diagnostics | → `azure-diagnostics` skill |
+| App Service / Container Apps logs | Deployed Azure | azure-diagnostics | → `azure-diagnostics` skill |
+| Logs/state | Deployed Docker / Compose | Docker CLI | `docker logs <container>`, `docker compose logs <service>` |
+
+**Decision tree:**
+
+1. Is this about **AppHost code or deployment definition**? → `aspire-deployment` skill.
+2. Is the app **running locally** via `aspire start`? → Aspire CLI.
+3. Is it deployed to **AKS**? → kubectl + Container Insights for workload; `azure-diagnostics` for the cluster's Azure resources.
+4. Is it deployed to **other Azure** (App Service, Container Apps)? → `azure-diagnostics`.
+5. Is it deployed to **Docker / Compose**? → `docker` / `docker compose` CLI.
+
+See [diagnostics-bridge.md](references/diagnostics-bridge.md) for detailed routing.
+
+## Investigation Workflow
+
+When something is wrong, investigate before editing code:
+
+1. `aspire describe` — check resource state and endpoints
+2. `aspire otel logs <resource>` — structured logs first
+3. `aspire logs <resource>` — console output as secondary view
+4. `aspire otel traces <resource>` — cross-service activity
+5. `aspire export` — zipped telemetry snapshot for deeper analysis
+
+## Local Commands Reference
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `aspire logs <resource>` | Console stdout/stderr | `aspire logs apiservice` |
+| `aspire logs --follow` | Stream logs in real-time | `aspire logs apiservice --follow` |
+| `aspire otel logs` | Structured OpenTelemetry logs | `aspire otel logs` |
+| `aspire otel traces` | Distributed trace data | `aspire otel traces` |
+| `aspire otel spans` | Individual span detail | `aspire otel spans` |
+| `aspire otel logs --trace-id <id>` | Logs correlated to trace (⚠️ verify flag) | `aspire otel logs --trace-id abc123` |
+| `aspire otel logs --dashboard-url` | Query a standalone dashboard (login URL or base URL + `--api-key`) | `aspire otel logs --dashboard-url "http://localhost:18888/login?t=TOKEN" --follow` |
+| `aspire otel traces --dashboard-url` | Query a standalone dashboard | `aspire otel traces --dashboard-url "http://localhost:18888/login?t=TOKEN"` |
+| `aspire describe` | Resource state, endpoints, health | `aspire describe --format Json` |
+| `aspire describe --include-hidden` | Include proxies, helper containers, migrations | `aspire describe --include-hidden --format Json` |
+| `aspire ps --format Json` | Resource list with state (filtered) | `aspire ps --format Json` |
+| `aspire ps --include-hidden --format Json` | Resource list with hidden resources | `aspire ps --include-hidden --format Json` |
+| `aspire export` | Portable telemetry bundle | `aspire export` |
+| `aspire dashboard run` | Standalone dashboard (foreground/blocking) | `aspire dashboard run` |
+
+### Hidden resources are filtered by default
+
+`aspire ps`, `aspire describe`, and other CLI commands filter out resources marked hidden in the AppHost (proxies, helper containers, migrations). The default output is correct for normal app inspection. Add `--include-hidden` when:
+
+- Debugging proxies, sidecar/helper containers, or migration jobs.
+- An expected resource is "missing" from `aspire ps` / `aspire describe`.
+- Triaging connectivity or wiring issues that may involve infrastructure resources.
+
+### Tips for Agents
+
+```bash
+# ✅ Use --format Json for machine parsing (supported: ps, describe, start)
+aspire describe --format Json
+
+# ✅ When a resource you expect is missing, retry with --include-hidden
+aspire ps --include-hidden --format Json | jq '.[] | {name, displayName, state, hidden}'
+
+# ✅ Get endpoints from describe, not guessing ports
+ENDPOINT=$(aspire describe apiservice --format Json | jq -r '.endpoints[0].url')
+
+# ✅ Use --apphost <path> when multiple AppHosts exist
+aspire describe --apphost ./src/MyApp.AppHost/
+```
+
+## Known Diagnostics Issues
+
+| Issue | Symptom | Workaround |
+|-------|---------|-----------|
+| TS AppHost DNS failure ([#15782](https://github.com/microsoft/aspire/issues/15782)) | `aspire otel` "No such host" for `*.dev.localhost` | Use `--dashboard-url localhost:PORT` |
+| `--isolated` mode telemetry ([#16107](https://github.com/microsoft/aspire/issues/16107)) | OTEL port not randomized in isolated mode | Avoid `--isolated` if telemetry is needed |
+| Resource missing from `aspire ps` / `aspire describe` | Hidden-by-default resources such as proxies, helpers, or migrations | Re-run with `--include-hidden` |
+
+> **Resolved in 13.3**: The standalone-dashboard workaround for [#16236](https://github.com/microsoft/aspire/issues/16236) is obsolete — use `aspire dashboard run` (see below).
+
+## Standalone Dashboard (`aspire dashboard run`)
+
+`aspire dashboard run` launches the Aspire Dashboard without an AppHost, so any OTLP-emitting application (Aspire or not) can stream telemetry into it.
+
+```bash
+aspire dashboard run
+# Dashboard:  http://localhost:18888/login?t=<TOKEN>
+# OTLP/gRPC:  http://localhost:4317
+# OTLP/HTTP:  http://localhost:4318
+```
+
+> ⚠️ **Foreground / blocking.** `aspire dashboard run` does **not** return until you stop it (Ctrl-C). Agents must treat it as a long-running background process — start it with the bash tool's `mode="async"`, capture the dashboard URL and token from initial output, and leave it running. Do **not** invoke it as a one-shot synchronous command, and do **not** wait for it to "finish".
+
+### Connect the Aspire CLI to a standalone dashboard
+
+`aspire otel logs` and `aspire otel traces` accept `--dashboard-url`. The simplest form passes the full login URL printed by `aspire dashboard run` — the CLI normalizes it automatically:
+
+```bash
+# Stream structured logs from a standalone dashboard (login URL form)
+aspire otel logs --dashboard-url "http://localhost:18888/login?t=TOKEN" --follow
+
+# Search recent traces
+aspire otel traces --dashboard-url "http://localhost:18888/login?t=TOKEN"
+```
+
+For dashboards configured with API-key authentication (e.g., the standalone container image with a separate API key), pass `--api-key` alongside the base `--dashboard-url`:
+
+```bash
+aspire otel logs --dashboard-url https://my-dashboard.example.com --api-key "$DASHBOARD_API_KEY" --follow
+```
+
+The container-image standalone dashboard still works for environments where the CLI isn't available.
+
+## Browser Telemetry (`Aspire.Hosting.Browsers`)
+
+The `Aspire.Hosting.Browsers` integration captures **browser console logs, network requests, and screenshots** from frontend resources during local development and surfaces them in the dashboard alongside server-side telemetry. Frontend resources opt in via `WithBrowserLogs()`.
+
+| Need | Action |
+|------|--------|
+| Inspect browser telemetry that is already wired | Open the dashboard; browser logs / network / screenshots appear next to server telemetry for the resource |
+| Confirm a frontend has it enabled | Check the AppHost for `.WithBrowserLogs()` on the resource (e.g., `AddViteApp("frontend").WithBrowserLogs()`) |
+| Add `WithBrowserLogs()` to a resource | → **`aspireify` skill** (AppHost authoring) — do not edit the AppHost from this skill |
+
+When parsing telemetry programmatically, browser logs surface as additional OTLP log records associated with the frontend resource — `aspire otel logs <frontend-resource>` returns them alongside server logs.
+
+## Dashboard UX Features
+
+Agents inspecting a running dashboard should know:
+
+- **Notification center** (bell icon, top-right) — surfaces results of resource commands and lifecycle events. Inline command responses appear here instead of being scraped from the logs panel.
+- **Rebuild command** — available on container and project resources; rebuilds the image and restarts the resource without restarting the whole AppHost. Result lands in the notification center.
+- **Structured command results** — custom resource commands return `ExecuteCommandResult` with a `Message` payload that the dashboard renders inline; HTTP commands set `HttpCommandResultMode.Auto | Json | Text | None` to control how the response body is shown.
+
+> Authoring custom commands or `WithBrowserLogs()` calls is AppHost work — route to **`aspireify`**. This skill is for *observing* what those features surface in the dashboard.
+
+## Why Aspire CLI Can't Do Remote Diagnostics
+
+The Aspire CLI talks to a *running AppHost* through a local backchannel socket at `~/.aspire/backchannels/`. This is **by design** — there is no remote backchannel. For deployed apps, route to platform-specific tools (azure-diagnostics, kubectl, docker).
+
+**Exception**: if a Dashboard is reachable (deployed alongside the app, or running standalone), `aspire otel logs` and `aspire otel traces` can query it via `--dashboard-url` (login URL form) and optional `--api-key` (see the Standalone Dashboard section above). This does **not** apply to `aspire logs` or `aspire describe`.
+
+## Handoff Rules
+
+| Scenario | Route To |
+|----------|----------|
+| Start/stop/wait/rebuild lifecycle | → `aspire-orchestration` skill |
+| Deploy, publish, pipeline steps, AppHost compute environment binding | → `aspire-deployment` skill |
+| AppHost code changes (`WithBrowserLogs()`, custom commands, `WithHttpCommand`) | → `aspireify` skill |
+| Deployed Azure resource health (App Insights, Front Door, NSP, private endpoint, ACA, App Service) | → `azure-diagnostics` skill (azure-skills) |
+| AKS workload diagnostics (pod logs, pod state, Container Insights) | → `kubectl` + Azure Monitor Container Insights |
+| Docker / Compose container logs | → `docker logs` / `docker compose logs` |
+
+## Project-Local Skill Routing
+
+If `.agents/skills/aspire/SKILL.md` exists (from `aspire agent init`), see its
+`references/monitoring.md` for deeper telemetry workflow guidance.
+
+## References
+
+- [diagnostics-bridge.md](references/diagnostics-bridge.md) — Local vs deployed routing detail
+- [monitoring.md](references/monitoring.md) — Telemetry inspection and export patterns
+- [playwright-handoff.md](references/playwright-handoff.md) — Find the correct Aspire frontend URL before browser testing

--- a/.agents/skills/aspire-monitoring/references/diagnostics-bridge.md
+++ b/.agents/skills/aspire-monitoring/references/diagnostics-bridge.md
@@ -1,0 +1,209 @@
+# Diagnostics Bridge — Local vs Deployed
+
+> **Purpose**: Route diagnostics requests to the correct tool based on where the application is running.
+
+## Decision Flowchart
+
+```
+Is the request about AppHost code or deployment definition?
+│
+├── YES → Route to aspire-deployment skill (and aspireify for code edits)
+│
+└── NO → Is the app running locally (via aspire start)?
+    │
+    ├── YES → Use Aspire CLI
+    │   ├── Console logs       → aspire logs <resource>
+    │   ├── Structured logs    → aspire otel logs
+    │   ├── Traces             → aspire otel traces
+    │   ├── Spans              → aspire otel spans
+    │   ├── Resource state     → aspire describe   (add --include-hidden if missing)
+    │   ├── Export telemetry   → aspire export
+    │   ├── Filter by trace    → aspire otel logs --trace-id <id> (verify flag)
+    │   └── Standalone dash    → aspire dashboard run  (foreground/blocking)
+    │
+    └── NO (deployed) → Route by target
+        ├── Azure Kubernetes Service (AKS)
+        │   ├── Pod logs           → kubectl logs <pod>
+        │   ├── Pod / workload state → kubectl describe pod <pod>, kubectl get pods
+        │   ├── Cluster Azure resources → azure-diagnostics skill
+        │   └── Cluster-wide telemetry → Azure Monitor Container Insights
+        │
+        ├── Other Azure (App Service, Container Apps) → azure-diagnostics skill
+        │   ├── App logs           → az containerapp logs show / az webapp log tail
+        │   ├── Metrics            → az monitor metrics list
+        │   ├── App Insights       → az monitor app-insights query
+        │   ├── Resource health    → az resource show / AppLens
+        │   └── Front Door / NSP / private endpoint → azure-diagnostics
+        │
+        └── Docker / Compose → Use Docker tooling
+            ├── Container logs     → docker logs <container>
+            ├── Service logs       → docker compose logs <service>
+            └── Resource state     → docker ps / docker compose ps
+```
+
+---
+
+## Local Development — Full Aspire CLI Support
+
+When the app is running locally via `aspire start`, the Aspire CLI provides complete observability:
+
+### How It Works
+
+The Aspire CLI communicates with the running AppHost through a **backchannel socket** at `~/.aspire/backchannels/`. This is a local-only IPC mechanism — it cannot connect to remote instances.
+
+### Available Commands
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `aspire logs <resource>` | Console stdout/stderr from a resource | `aspire logs apiservice` |
+| `aspire logs --follow` | Stream logs in real-time | `aspire logs apiservice --follow` |
+| `aspire otel logs` | Structured OpenTelemetry log records | `aspire otel logs` |
+| `aspire otel traces` | Distributed trace data | `aspire otel traces` |
+| `aspire otel spans` | Individual span-level detail | `aspire otel spans` |
+| `aspire otel logs --trace-id <id>` | Logs correlated to a specific trace (⚠️ verify flag in your version) | `aspire otel logs --trace-id abc123` |
+| `aspire otel logs --dashboard-url` | Query a standalone or deployed dashboard | `aspire otel logs --dashboard-url "https://localhost:18888/login?t=TOKEN"` |
+| `aspire describe` | Resource state, endpoints, health (filtered) | `aspire describe --format Json` |
+| `aspire describe --include-hidden` | Include hidden resources (proxies, helpers, migrations) | `aspire describe --include-hidden --format Json` |
+| `aspire ps --include-hidden --format Json` | Resource list including hidden resources | `aspire ps --include-hidden --format Json` |
+| `aspire export` | Export portable telemetry bundle | `aspire export` |
+| `aspire dashboard run` | Run the Aspire Dashboard standalone (foreground/blocking) | `aspire dashboard run` |
+
+### Tips for Agents
+
+```bash
+# ✅ Always use --format Json for machine parsing
+aspire describe --format Json
+
+# ✅ When an expected resource is missing, retry with --include-hidden
+#    Hidden-by-default resources (proxies, helper containers, migrations)
+aspire ps --include-hidden --format Json
+
+# ✅ Get endpoints from describe, not guessing ports
+ENDPOINT=$(aspire describe apiservice --format Json | jq -r '.endpoints[0].url')
+
+# ✅ Correlate logs to a specific request
+aspire otel logs --trace-id <trace-id-from-otel-traces>
+```
+
+---
+
+## Standalone Dashboard — `aspire dashboard run`
+
+`aspire dashboard run` runs the Aspire Dashboard without an AppHost — point any OTLP-emitting application at it (Aspire or not) and telemetry shows up live.
+
+```bash
+aspire dashboard run
+# Dashboard:  http://localhost:18888/login?t=<TOKEN>
+# OTLP/gRPC:  http://localhost:4317
+# OTLP/HTTP:  http://localhost:4318
+```
+
+> ⚠️ **Foreground / blocking.** This command does not return until you stop it (Ctrl-C). Agents must start it as a long-running background process (e.g., bash `mode="async"`), capture the dashboard URL and `t=` token from initial output, and leave it running. Do **not** treat it as a one-shot synchronous command.
+
+### Connect the CLI to a standalone dashboard
+
+The `aspire otel logs` and `aspire otel traces` commands accept `--dashboard-url` (and `--api-key` when the dashboard is configured with API-key auth) so the CLI can query a standalone dashboard without an AppHost.
+
+The simplest form passes the full login URL printed by `aspire dashboard run` — the CLI normalizes login URLs automatically:
+
+```bash
+# Stream structured logs (login URL form — token in URL)
+aspire otel logs --dashboard-url "http://localhost:18888/login?t=TOKEN" --follow
+
+# Search recent traces
+aspire otel traces --dashboard-url "http://localhost:18888/login?t=TOKEN"
+```
+
+For dashboards that use a separate API key (e.g., the standalone container image with API-key auth configured), pass `--api-key` alongside the base URL:
+
+```bash
+aspire otel logs --dashboard-url https://my-dashboard.example.com --api-key "$DASHBOARD_API_KEY" --follow
+```
+
+The container-image standalone dashboard is still available where the CLI isn't an option.
+
+---
+
+## Browser Telemetry (`Aspire.Hosting.Browsers`)
+
+The `Aspire.Hosting.Browsers` integration captures **browser console logs, network requests, and screenshots** from frontend resources during local development. Frontend resources opt in by calling `WithBrowserLogs()` in the AppHost. The data shows up in the dashboard alongside server-side telemetry.
+
+| Need | Action |
+|------|--------|
+| Inspect existing browser telemetry | Open the dashboard or run `aspire otel logs <frontend-resource>` |
+| Check whether a frontend has it enabled | Look for `.WithBrowserLogs()` in the AppHost |
+| Add `WithBrowserLogs()` to a resource | → **`aspireify` skill** (AppHost authoring) |
+
+---
+
+## Deployed Applications — Routing
+
+### Why Aspire CLI Cannot Help Directly
+
+The Aspire CLI's `aspire logs`, `aspire describe`, and other backchannel commands use the local backchannel socket at `~/.aspire/backchannels/`. This is **by design** — there is no remote backchannel. When an app is deployed, the Aspire CLI cannot reach it directly.
+
+**Exception:** if a Dashboard is reachable (deployed alongside the app, or running standalone), `aspire otel logs --dashboard-url` and `aspire otel traces --dashboard-url` (with `--api-key` when the dashboard requires it) can query it remotely. This does **not** extend to `aspire logs` or `aspire describe`.
+
+```bash
+# Limited remote support via deployed Dashboard — login URL form
+aspire otel logs --dashboard-url "https://my-dashboard.azurecontainerapps.io/login?t=TOKEN"
+aspire otel traces --dashboard-url "https://my-dashboard.azurecontainerapps.io/login?t=TOKEN"
+
+# Or with separate API-key auth
+aspire otel logs --dashboard-url https://my-dashboard.azurecontainerapps.io --api-key "$DASHBOARD_API_KEY"
+```
+
+### Three-way deployed routing
+
+| Target | Use | Examples |
+|--------|-----|----------|
+| **AKS workload (pod logs, pod state, container insights)** | `kubectl` + Azure Monitor Container Insights | `kubectl logs <pod>`, `kubectl describe pod <pod>`, Container Insights queries |
+| **Azure resource health** (App Insights, Front Door, NSP, private endpoint, ACA, App Service) | `azure-diagnostics` skill (azure-skills) | `az containerapp logs show`, `az monitor app-insights query`, AppLens |
+| **Docker / Compose** | Docker CLI | `docker logs <container>`, `docker compose logs <service>` |
+
+### azure-diagnostics — quick reference
+
+| Need | azure-diagnostics Approach |
+|------|---------------------------|
+| Application logs | `az containerapp logs show --name APP -g RG --follow` |
+| Metrics | `az monitor metrics list --resource RESOURCE_ID` |
+| App Insights queries | `az monitor app-insights query --analytics-query "KQL"` |
+| Resource health | AppLens MCP tool or `az resource show` |
+| Activity log | `az monitor activity-log list -g RG` |
+| Front Door / NSP / private endpoint | `az network front-door`, `az network perimeter`, AppLens |
+
+### Production Telemetry — Automatic Configuration
+
+Aspire auto-configures Application Insights when `AddAzureApplicationInsights()` is used in the AppHost. Deployed apps export OpenTelemetry data to App Insights automatically, providing:
+
+- Request traces and dependency tracking
+- Exception logging
+- Performance metrics
+- Live Metrics stream
+- Application Map (service topology)
+
+No additional configuration is needed — Aspire wires the connection string during deployment.
+
+## Known Diagnostics Issues
+
+| Issue | Symptom | Workaround |
+|-------|---------|-----------|
+| TS AppHost DNS failure ([#15782](https://github.com/microsoft/aspire/issues/15782)) | `aspire otel` returns "No such host" for `*.dev.localhost` | Use `--dashboard-url localhost:PORT` directly |
+| `--isolated` mode telemetry ([#16107](https://github.com/microsoft/aspire/issues/16107)) | OTEL port not randomized in isolated mode | Avoid `--isolated` if telemetry is needed |
+| Resource missing from `aspire ps` / `aspire describe` | Hidden-by-default resources such as proxies, helpers, or migrations | Re-run with `--include-hidden` |
+
+> **Resolved in 13.3**: The standalone-dashboard workaround for [#16236](https://github.com/microsoft/aspire/issues/16236) is obsolete — `aspire dashboard run` ships in-box (see Standalone Dashboard section above).
+
+---
+
+## Summary: Where to Look
+
+| Question | Local Dev | Deployed |
+|----------|-----------|----------|
+| "What's the status of my resources?" | `aspire describe` (try `--include-hidden` if missing) | Azure Portal / `az containerapp show` / `kubectl describe pod` |
+| "Show me the logs" | `aspire logs <resource>` | `az containerapp logs show` / `kubectl logs <pod>` / `docker logs` |
+| "Show me distributed traces" | `aspire otel traces` | App Insights → Transaction Search |
+| "Why is this resource unhealthy?" | `aspire describe` + `aspire logs` | AppLens / azure-diagnostics / `kubectl describe pod` |
+| "What metrics are available?" | Aspire Dashboard (auto-launched or `aspire dashboard run`) | Azure Monitor / App Insights / Container Insights |
+| "Export telemetry for analysis" | `aspire export` | App Insights export / KQL query |
+| "Browser console / network logs" | Dashboard (with `WithBrowserLogs()` enabled) — N/A in production |

--- a/.agents/skills/aspire-monitoring/references/monitoring.md
+++ b/.agents/skills/aspire-monitoring/references/monitoring.md
@@ -1,0 +1,200 @@
+# Monitoring
+
+Use this when the task is about inspecting app state, logs, traces, endpoints, or sharable diagnostics.
+
+## Scenario: I Need To Know What Is Running And Where The Endpoints Are
+
+Use these commands when the first job is to inspect current resource state, find URLs, or hand machine-readable app state to another tool.
+
+```bash
+aspire describe
+aspire resources
+aspire describe --apphost <path>
+aspire describe --apphost <path> --format Json
+```
+
+Keep these points in mind:
+
+- Use `aspire describe` first when you need the current state of the running app before deciding what to do next.
+- Use `--apphost <path>` when the workspace has multiple AppHosts or discovery is ambiguous.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+
+## Scenario: Something Is Wrong, But Investigate Before Editing Code
+
+Use these commands when the task is to diagnose behavior in the live app before making code changes.
+
+```bash
+aspire otel logs [resource] --format Json
+aspire otel traces [resource] --format Json
+aspire otel spans [resource] --format Json
+aspire otel logs --trace-id <id> --format Json
+aspire otel logs [resource] --search "connection timeout"
+aspire otel traces [resource] --search "/api/products"
+aspire otel logs [resource] --search "severity:error"
+aspire otel spans [resource] --search "@http.method:GET duration:>100"
+aspire logs [resource]
+aspire logs [resource] --search "error"
+```
+
+Keep these points in mind:
+
+- Prefer structured telemetry before raw console logs when possible.
+- Use `aspire logs` as a secondary console-output view after checking structured telemetry.
+- Use the trace-filtered log command when you already have a trace id and want the related log slice.
+- Use `--search` to filter results by a case-insensitive text match across all fields (messages, attribute keys/values, trace/span IDs, resource names, severity, scope names). This is the fastest way to narrow output when you know what you're looking for.
+- Prefer `--format Json` when another tool or script needs to consume the result, such as a Playwright handoff or endpoint extraction.
+- `[resource]` is optional. Include it to filter results to a single resource; omit it to see all resources.
+- `--search` can be combined with other options like `--format Json`, `--trace-id`, `--limit`, and resource filtering.
+
+## Filtering
+
+The `--search` option filters output by matching text against log content and trace/span content.
+
+- Multiple words are AND'd — all fragments must match.
+- Use `"quoted phrases"` for multi-word fragments: `--search "\"connection timeout\""`.
+- Qualifiers support quoted values: `--search "message:\"connection failed\""`.
+
+### Console Logs (`aspire logs --search`)
+
+Matches against log line text content and resource name. Only free-text is supported (no structured qualifiers).
+
+```bash
+aspire logs redis --search "timeout"
+aspire logs --follow --search "\"connection error\""
+```
+
+### Structured Telemetry (`aspire otel logs/traces/spans --search`)
+
+Supports free-text and structured qualifiers in a single query.
+
+**Free-text** matches against message, resource name, scope, trace/span IDs, severity/status, and all attribute keys/values.
+
+**Structured qualifiers** filter on specific fields with `key:value` syntax:
+
+- Log keys: `severity`, `resource`, `scope`, `message`, `trace-id`, `span-id`, `event`
+- Span/Trace keys: `name`, `resource`, `scope`, `status`, `kind`, `trace-id`, `span-id`, `duration`
+- Custom attributes: `@http.method:GET`, `@db.system:redis`
+- Negation: `-severity:debug`, `-@db.system:redis`
+- Comparison: `duration:>100`, `duration:>=50`
+
+```bash
+aspire otel logs --search "severity:error \"connection failed\""
+aspire otel spans --search "@http.method:GET duration:>100 status:error"
+aspire otel logs --search "resource:api -severity:debug"
+```
+
+## Scenario: I Need A Sharable Diagnostics Bundle
+
+Use this command when you need a portable handoff artifact for deeper analysis or for another person to inspect offline.
+
+```bash
+aspire export [resource]
+```
+
+Keep these points in mind:
+
+- Use `aspire export` when you need a sharable bundle of telemetry and resource state.
+- `[resource]` is optional. Include it to filter the export to a single resource; omit it to export all resources.
+- The output is a zip archive (default name `aspire-export-<timestamp>.zip`) containing up to four directories:
+  - `resources/` — one JSON file per resource with resource details (name, type, state, endpoints, environment variables, etc.).
+  - `consolelogs/` — one plain-text file per resource with raw console output lines.
+  - `structuredlogs/` — one JSON file per resource with structured log entries in OTLP format.
+  - `traces/` — one JSON file per resource with distributed traces and spans in OTLP format.
+- When extracting the export for analysis, look at `resources/` first for an overview, then drill into `consolelogs/`, `structuredlogs/` and `traces/` for detailed diagnostics.
+
+## Dashboard Links
+
+Commands like `aspire describe`, `aspire otel logs`, `aspire otel traces`, and `aspire otel spans` may include dashboard URLs in their JSON output. Only use URLs that are explicitly returned by these commands — do not construct dashboard URLs yourself.
+
+When a dashboard link is returned alongside a resource or telemetry entry, make the resource name, trace ID, or span ID a clickable markdown link using the returned URL.
+
+## Displaying Resources
+
+When showing resource state to the user, display the state text with a circle emoji prefix:
+
+- 🟢 Running, healthy
+- 🟡 Starting, waiting
+- 🔴 Failed, error, unhealthy
+- ⚪ Stopped, exited
+
+Link resource names to their dashboard page when the dashboard URL is known.
+
+## Displaying Telemetry
+
+When showing structured logs, prefix each entry with an emoji matching the log level:
+
+- 🔴 Error / Critical
+- 🟡 Warning
+- 🔵 Information
+- ⚪ Debug / Trace
+
+Link resource names to their dashboard resource page. When trace IDs are present, display the first 7 characters and link that value to the full trace detail page.
+
+When showing traces or spans, use 🟢 for success/unset status and 🔴 for error status. Display only the first 7 characters of trace and span IDs, and link those values to their dashboard detail pages.
+
+## Production Monitoring Strategy (Azure)
+
+Aspire auto-configures Application Insights when `AddAzureApplicationInsights()` is used in the AppHost. Deployed Azure apps export OpenTelemetry to App Insights automatically:
+
+- Request traces and dependency tracking
+- Exception logging
+- Performance metrics
+- Live Metrics stream
+- Application Map (service topology)
+
+No additional configuration is needed for Azure once the AppHost and deployment target wire the connection strings during deployment.
+
+> **Docker Compose / Kubernetes**: Auto-configured App Insights does not apply. These targets require platform-native observability (Prometheus, Grafana, ELK, etc.) unless the app is explicitly configured to export OTEL to an external collector.
+
+## Deployed App Monitoring — Route by Target
+
+| Target | Tool | Commands |
+|--------|------|----------|
+| Azure Container Apps / App Service | azure-diagnostics | `az containerapp logs show`, `az webapp log tail`, App Insights |
+| Azure resource health (Front Door, NSP, private endpoint, App Insights) | azure-diagnostics | AppLens, `az monitor app-insights query` |
+| AKS workload (pods, workloads) | kubectl + Container Insights | `kubectl logs <pod>`, `kubectl describe pod <pod>`, Azure Monitor Container Insights |
+| Docker / Compose | Docker CLI | `docker logs <container>`, `docker compose logs <service>` |
+
+## Standalone Dashboard (`aspire dashboard run`)
+
+`aspire dashboard run` launches the Aspire Dashboard without an AppHost, so any OTLP-emitting application can stream telemetry into it.
+
+```bash
+aspire dashboard run
+# Dashboard:  http://localhost:18888/login?t=<TOKEN>
+# OTLP/gRPC:  http://localhost:4317
+# OTLP/HTTP:  http://localhost:4318
+```
+
+> **Foreground / blocking.** `aspire dashboard run` does not return until stopped. Agents must treat it as a long-running background process, capture the dashboard URL and token from initial output, and leave it running. Do not invoke it as a one-shot synchronous command, and do not wait for it to "finish".
+
+### Connect the Aspire CLI to a standalone dashboard
+
+`aspire otel logs` and `aspire otel traces` accept `--dashboard-url`. The simplest form passes the full login URL printed by `aspire dashboard run`; the CLI normalizes it automatically:
+
+```bash
+aspire otel logs --dashboard-url "http://localhost:18888/login?t=TOKEN" --follow
+aspire otel traces --dashboard-url "http://localhost:18888/login?t=TOKEN"
+```
+
+For dashboards configured with API-key authentication, pass `--api-key` alongside the base `--dashboard-url`:
+
+```bash
+aspire otel logs --dashboard-url https://my-dashboard.example.com --api-key "$DASHBOARD_API_KEY" --follow
+```
+
+## Browser Telemetry
+
+Frontend resources opted into `Aspire.Hosting.Browsers` via `WithBrowserLogs()` surface browser console logs, network requests, and screenshots in the dashboard alongside server-side telemetry.
+
+| Need | Action |
+|------|--------|
+| Inspect browser telemetry that is already wired | Open the dashboard; browser logs / network / screenshots appear next to server telemetry for the resource |
+| Confirm a frontend has it enabled | Check the AppHost for `.WithBrowserLogs()` on the resource |
+| Add `WithBrowserLogs()` to a resource | Route to `aspireify`; this is AppHost authoring, not monitoring |
+
+## Why Aspire CLI Can't Do Remote Diagnostics
+
+The Aspire CLI talks to a *running AppHost* through a local backchannel socket at `~/.aspire/backchannels/`. This is by design — there is no remote backchannel. For deployed apps, route to platform-specific tools such as azure-diagnostics, kubectl, or Docker.
+
+**Exception**: if a Dashboard is reachable (deployed alongside the app, or running standalone), `aspire otel logs` and `aspire otel traces` can query it via `--dashboard-url` and optional `--api-key`. This does not apply to `aspire logs` or `aspire describe`.

--- a/.agents/skills/aspire-monitoring/references/playwright-handoff.md
+++ b/.agents/skills/aspire-monitoring/references/playwright-handoff.md
@@ -1,0 +1,21 @@
+# Playwright Handoff
+
+Use this when Playwright CLI is already configured and the next step is browser testing against a running Aspire app.
+
+## Scenario: I Need The Right Frontend URL Before Browser Testing
+
+Use these commands when the task is to discover the live frontend endpoint from Aspire state and then hand that URL to Playwright.
+
+```bash
+aspire describe --format Json
+aspire describe --apphost <path> --format Json
+playwright-cli --help
+```
+
+Keep these points in mind:
+
+- Aspire discovers the endpoint first; Playwright uses the discovered endpoint after the handoff.
+- Prefer `aspire describe --format Json` when the URL needs to be consumed by a script or passed to another tool.
+- Use `--apphost <path>` when multiple AppHosts exist and the user is asking about one specific app.
+- Do not guess frontend endpoints without first consulting Aspire state.
+- If multiple frontends exist, use Aspire state to disambiguate which URL Playwright should use.

--- a/.agents/skills/aspire-orchestration/SKILL.md
+++ b/.agents/skills/aspire-orchestration/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: aspire-orchestration
+description: >-
+  **WORKFLOW SKILL** — Manage Aspire AppHost lifecycle and recover from file locks,
+  port conflicts, and orphaned processes. WHEN: "start my Aspire app", "aspire start",
+  "aspire stop", "aspire wait", "restart the API service", "file lock error",
+  "MSB3491", "CS2012", "port already in use", "upgrade Aspire CLI", "aspire update --self",
+  "proxies missing in aspire ps", "--include-hidden", "aspire integration list",
+  "aspire integration search", "default watch", "hot reload". INVOKES: aspire CLI
+  (start, stop, wait, ps, resource, integration, add, init, doctor, update, restore).
+  FOR SINGLE OPERATIONS: Run the aspire CLI command directly.
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.1"
+---
+
+# Aspire Orchestration
+
+> **MANDATORY COMPLIANCE** — This skill prevents agent self-harm in Aspire projects.
+> Violating these rules causes file locks, orphaned processes, and user frustration ([#15801](https://github.com/microsoft/aspire/issues/15801)).
+
+## Prerequisites
+
+| Requirement | Install |
+|-------------|---------|
+| .NET 10.0 SDK | https://dotnet.microsoft.com/download |
+| Aspire CLI (curl/PowerShell) | `curl -sSL https://aspire.dev/install.sh \| bash` |
+| Aspire CLI (NativeAOT global tool, .NET 10) | `dotnet tool install -g Aspire.Cli` |
+
+Either install method works. The `dotnet tool install` path produces a NativeAOT binary
+(instant startup, no JIT warmup) and is the recommended option when .NET 10 is already present.
+
+## Detection
+
+Activate when ANY signal is present:
+
+| Signal | How to Detect | Confidence |
+|--------|---------------|------------|
+| C# AppHost | `.csproj` containing `Aspire.AppHost.Sdk` | ✅ Definitive |
+| File-based C# AppHost | `apphost.cs` or `.cs` file with `#:sdk Aspire.AppHost.Sdk` | ✅ Definitive |
+| TypeScript AppHost | `apphost.ts` file in project | ✅ Definitive |
+| Aspire config | `aspire.config.json` in project root | High |
+| Aspire settings | `.aspire/` directory present | High |
+| Generated TS modules | `.aspire/modules/` directory present | High |
+| Service defaults | `Aspire.ServiceDefaults` in project references | Medium |
+
+See [detection.md](references/detection.md) for detailed fingerprinting.
+
+## Safety Guardrails
+
+| Situation | ✅ ALWAYS Do | ❌ NEVER Do |
+|-----------|-------------|------------|
+| Start an Aspire app | `aspire start` | `dotnet run` on AppHost |
+| Wait for resource ready | `aspire wait <resource>` | `curl` / HTTP polling loops |
+| Code changed in a resource | Prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging | `dotnet build` against locked files |
+| Task complete | `aspire stop` | Leave processes running |
+| Check resource status | `aspire describe` / `aspire ps` | Manual process inspection |
+| Working in git worktree | `aspire start --isolated` | `aspire start` without isolation |
+| Running from AI agent | Add `--non-interactive` to all commands | Assuming interactive terminal |
+| Editing unfamiliar API | `aspire docs search <topic>` then `aspire docs api search <query>` for API reference | Guessing API shape |
+| C# AppHost API inspection | Use `dotnet-inspect` skill (if available) for local symbols | Guessing overloads or builder chains |
+| Adding custom dashboard/resource commands | `aspire docs search "custom resource commands"` first | Inventing `WithCommand` patterns without docs |
+| Installing Aspire support | Use `aspire add` or `aspire init` | ~~`dotnet workload install aspire`~~ (obsolete) |
+
+See [safety-guardrails.md](references/safety-guardrails.md) for detailed rules and recovery patterns.
+
+## Default Workflow
+
+1. Confirm workspace is Aspire — identify the AppHost
+2. `aspire start` (or `aspire start --isolated` in worktrees)
+3. `aspire wait <resource>` before interacting with any resource
+4. `aspire describe` to inspect state, then work
+5. If AppHost code changed, rerun `aspire start`; if only one resource changed, prefer the resource's commands/watch/HMR/debug workflow
+6. `aspire stop` when cleanup is explicitly requested or needed to release locks/ports
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Start app (agents) | `aspire start` (background, preferred) |
+| Start app (human) | `aspire run` (foreground, dashboard) |
+| Stop app | `aspire stop` |
+| Wait for resource | `aspire wait <resource>` |
+| Check status | `aspire ps` or `aspire describe` |
+| Show hidden resources (proxies, helpers, migrations) | `aspire ps --include-hidden` / `aspire describe --include-hidden` |
+| Resource operation | `aspire resource <resource-name> <command>` such as `stop`, `start`, or `rebuild` when exposed |
+| Create new project | `aspire new aspire-starter` |
+| Add Aspire to existing | `aspire init` (then hand off to `aspireify` skill for wiring) |
+| Add integration | `aspire add <package>` |
+| Discover integrations | `aspire integration list --format Json` / `aspire integration search <query> --format Json` |
+| Upgrade the CLI itself | `aspire update --self` |
+| Update project package refs | `aspire update` (modifies project files — get user approval) |
+| Restore generated files | `aspire restore` |
+| Environment maintenance | `aspire cache clear`, `aspire certs trust`, `aspire certs clean` |
+| Diagnose environment | `aspire doctor` |
+| Machine-readable output | `--format Json` (supported: `ps`, `describe`, `start`) |
+| Look up API reference | `aspire docs api search <query> --language csharp\|typescript` |
+| Browse API entries | `aspire docs api list <scope>` |
+| Get API detail | `aspire docs api get <id>` |
+
+## Error Handling
+
+| Symptom | Cause | Action |
+|---------|-------|--------|
+| **File lock errors during build (`MSB3491`, `CS2012`)** | **Aspire is running and holds locks on `bin/`, `obj/`, and assemblies.** | **Run `aspire stop` first**, then rebuild or `aspire start`. Do NOT conclude the project has a permanent build failure. |
+| "Port already in use" | Previous instance running | `aspire stop`, then `aspire start` |
+| Resource not found | App not started or name wrong | `aspire ps` to check |
+| Build errors in resource | Code error, not Aspire issue | Fix code, then use resource commands/watch/HMR/debug workflow or rerun `aspire start` if AppHost code changed |
+| Environment issues | Missing SDK or tools | `aspire doctor` to diagnose |
+| JSON parse failure from `aspire start` | Mixed human/JSON output ([#15843](https://github.com/microsoft/aspire/issues/15843)) | Strip non-JSON lines before parsing |
+| `aspire wait` rejects name | Use `displayName` not `name` ([#15842](https://github.com/microsoft/aspire/issues/15842)) | Use `displayName` from `aspire ps --format Json` |
+| `aspire ps` hangs | AppHost on breakpoint ([#15576](https://github.com/microsoft/aspire/issues/15576)) | Use timeout, check AppHost process |
+| `aspire agent init` fails | Non-interactive terminal ([#16264](https://github.com/microsoft/aspire/issues/16264)) | Run from standard terminal |
+| Docker daemon unavailable | Container-backed resources fail to start | Start Docker Desktop, then `aspire start` |
+| Multiple AppHosts detected | Wrong AppHost targeted | Use `--apphost <path>` to specify explicitly |
+
+### 🔒 File-Lock Recovery (MSB3491 / CS2012) — Always `aspire stop` First
+
+When a build fails with `error MSB3491: Could not write to output file ...` or
+`error CS2012: Cannot open ... for writing`, the project itself is healthy —
+**Aspire is running and holding file locks** on the resource's output assemblies.
+The recovery is always the same:
+
+```bash
+# ✅ Correct recovery sequence
+aspire stop              # release the locks
+# ... then either rebuild / restart one resource if the resource exposes commands ...
+aspire resource <name> rebuild   # example: C# project resource with rebuild command
+# ... or restart the whole AppHost ...
+aspire start             # if AppHost code changed or Aspire was already stopped
+```
+
+| ❌ NEVER do | ✅ ALWAYS do |
+|------------|-------------|
+| Tell the user the project has a permanent build failure | Recognize the lock as Aspire holding outputs and run `aspire stop` |
+| `dotnet build` again with locks held | `aspire stop` first, then `dotnet build` (or prefer resource commands/watch/HMR/debug workflow) |
+| Delete `bin/` / `obj/` to "fix" the lock | `aspire stop` — deletion may succeed but the next build relocks |
+| `pkill dotnet` or `kill <PID>` to free locks | `aspire stop` — clean shutdown via the CLI, no orphans |
+| Tell the user to "reboot" or "restart your machine" | `aspire stop` — single command, instant fix |
+
+The same rule applies to any "file in use", "cannot access the file", or
+"another process is using" error during a build of an Aspire-managed resource.
+
+## Handoff Rules
+
+| Scenario | Route To |
+|----------|----------|
+| AppHost wiring after `aspire init` (scan repo, add resources, ServiceDefaults/OTel) | → `aspireify` skill ([`../aspireify/SKILL.md`](../aspireify/SKILL.md)) or project-local `.agents/skills/aspireify/SKILL.md` |
+| Browser logs (`Aspire.Hosting.Browsers` / `WithBrowserLogs()`) and dashboard authoring | → `aspireify` skill (code edits) and `aspire-monitoring` (discovery) |
+| Custom resource commands (`WithCommand`, `ExecuteCommandResult`, `HttpCommandResultMode`) | → `aspireify` skill |
+| Lifecycle hooks (`SubscribeBeforeStart`, `SubscribeAfterResourcesCreated`, BeforeStart pipeline phase) | → `aspireify` skill |
+| Endpoint authoring (`WithEndpoint` updates, `ExcludeReferenceEndpoint` flag) | → `aspireify` skill |
+| Deploy, publish, pipeline steps, `aspire destroy` | → `aspire-deployment` skill |
+| Logs, traces, metrics, dashboard, `aspire dashboard run` | → `aspire-monitoring` skill |
+| Deployed app diagnostics | → `azure-diagnostics` skill (azure-skills) |
+
+## Runtime Settings And Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ASPIRE_ENABLE_CONTAINER_TUNNEL` | `true` | Container tunnel provides uniform host connectivity across Docker Desktop, Docker Engine, and Podman. Set to `false` to opt out. |
+| `ASPIRE_ENVIRONMENT` | unset | Selects the environment-specific config profile — controls which `appsettings.{environment}.json` is loaded and which environment is reported in dashboard telemetry. |
+| `ASPIRE_DCP_USE_DEVELOPER_CERTIFICATE` | `true` | The Aspire trusted developer certificate is used by DCP on Windows. Set to `false` to opt out. |
+| `features.defaultWatchEnabled` | false unless configured | Enables Aspire default watch for supported C# and TypeScript AppHosts. Do not treat this as per-resource rebuild, restart, or hot reload for resource source changes. |
+
+## TypeScript AppHost Note
+
+Detection covers TS AppHosts (`apphost.ts`), but **all TS AppHost authoring is delegated to `aspireify`**.
+Current rules to apply when handing off:
+
+| Rule | Why |
+|------|-----|
+| Prefer unified `withEnvironment(name, value)` over deprecated per-kind helpers (`withEnvironmentEndpoint`, `withEnvironmentParameter`, `withEnvironmentConnectionString`, `withEnvironmentExpression`, `withEnvironmentFromOutput`, `withEnvironmentFromKeyVaultSecret`) | Per-kind helpers are deprecated — single API now handles all value types |
+| Never edit `.aspire/modules/` directly | Generated; use `aspire add <package>` to regenerate and `aspire restore` to recover missing files |
+| Use `aspire docs api search <query> --language typescript` for API lookup | TS surface differs from C# |
+
+## Skill Routing — In-Plugin Sibling Skills
+
+After `aspire init` drops a skeleton AppHost + `aspire.config.json`, route AppHost wiring
+(scan repo → propose resource graph → edit AppHost → wire `Aspire.ServiceDefaults` / OTel →
+validate via `aspire start`) to the in-plugin **aspireify** skill: [`../aspireify/SKILL.md`](../aspireify/SKILL.md).
+For first-run flows that only need the skeleton drop, see the in-plugin **aspire-init** skill:
+[`../aspire-init/SKILL.md`](../aspire-init/SKILL.md). This orchestration skill stays focused
+on lifecycle (start/stop/wait/restart) and never edits AppHost code itself.
+
+## Project-Local Skill Precedence
+
+If `.agents/skills/aspire/SKILL.md` exists (from `aspire agent init`), defer to it for:
+C# AppHost editing, TS AppHost editing, Playwright handoff, investigation workflows.
+Safety guardrails from this plugin ALWAYS apply.
+
+If `.agents/skills/aspireify/SKILL.md` exists project-locally (installed by `aspire init` in
+current Aspire), **warn the user** that a project-local aspireify skill is present and **defer to it**
+for AppHost wiring instead of the in-plugin sibling. Same precedence rule as the project-local
+`aspire` skill above: project-local wins, plugin guardrails still apply.
+
+## References
+
+- [safety-guardrails.md](references/safety-guardrails.md) — Detailed rules and recovery patterns
+- [detection.md](references/detection.md) — Project fingerprinting
+- [app-commands.md](references/app-commands.md) — App lifecycle and bootstrap commands
+- [resource-management.md](references/resource-management.md) — Resource wait, restart, and operations
+- [agent-workflows.md](references/agent-workflows.md) — Common agent investigation, integration, TypeScript, and handoff workflows

--- a/.agents/skills/aspire-orchestration/references/agent-workflows.md
+++ b/.agents/skills/aspire-orchestration/references/agent-workflows.md
@@ -1,0 +1,119 @@
+# Aspire Agent Workflows
+
+Use these patterns when a task needs investigation or orchestration rather than a one-off command lookup.
+
+## Scenario: I Am In A Worktree And Need A Safe Background Run
+
+Start the AppHost with `aspire start` so the CLI manages background execution. In git worktrees, use `--isolated` to avoid port conflicts and shared local state:
+
+```bash
+aspire start --isolated
+```
+
+If the next step depends on one resource, wait for it explicitly:
+
+```bash
+aspire start --isolated
+aspire wait myapi
+```
+
+Keep these points in mind:
+
+- In a git worktree, rerun `aspire start --isolated` whenever AppHost changes need to be picked up.
+- Outside worktrees, rerun `aspire start`.
+- Avoid `aspire run` in normal agent workflows because it blocks the terminal.
+
+## Scenario: I Changed Code While The AppHost Is Running
+
+Classify the change before restarting anything:
+
+1. If the AppHost model, AppHost code, integrations, resource definitions, or AppHost-level configuration changed, rerun the same AppHost start command. In a git worktree, use `aspire start --isolated`.
+2. If one resource's implementation changed, keep the AppHost running and use a resource-specific workflow.
+3. If an IDE is managing debugging or hot reload, defer to the IDE and avoid overlapping Aspire CLI restart, rebuild, or watch behavior.
+
+Use resource commands when the running AppHost already knows about the resource and only that resource needs to be operated on. Choose the resource command path that matches the resource.
+
+For a C# project resource that exposes rebuild:
+
+```bash
+aspire resource api rebuild
+aspire wait api
+```
+
+For a resource that needs a process restart and does not have a better resource-specific command:
+
+```bash
+aspire resource api stop
+aspire resource api start
+aspire wait api
+```
+
+Keep these points in mind:
+
+- Use `aspire resource <resource-name> <command>` as the command shape.
+- Use `aspire resource <resource-name> rebuild` when a C# project resource exposes rebuild and you need the resource to pick up compiled changes.
+- Use runtime or framework-native hot reload/watch for resource implementation loops when that workflow is available.
+- For frontend resources, remember that frameworks such as Vite, Next.js, and similar client-side JavaScript stacks often enable hot module replacement (HMR) by default. If HMR is already applying the change through the resource's dev server, do not force a resource or AppHost restart.
+- Do not restart the whole AppHost just because one resource changed or one resource needs to be rebuilt.
+- Aspire default watch is controlled by `features.defaultWatchEnabled`; use it for AppHost-centered CLI watch behavior, not as a replacement for resource-specific or IDE hot reload workflows.
+
+## Scenario: Something Is Wrong, But Do Not Edit Code Yet
+
+Inspect the live app before editing code:
+
+1. `aspire describe` to check resource state.
+2. `aspire otel logs <resource>` to inspect structured logs. Add `--search "<term>"` to filter by keyword.
+3. `aspire logs <resource>` to inspect console output. Add `--search "<term>"` to filter by keyword.
+4. `aspire otel traces <resource>` to follow cross-service activity. Add `--search "<term>"` to narrow results.
+5. `aspire export` when you need a zipped telemetry snapshot for deeper analysis or handoff.
+
+## Scenario: I Need To Add An Integration, Understand An API, Or Add A Custom Command Safely
+
+Use integration search to find the package when needed, then use the docs commands for the workflow and the API reference commands if you need the concrete API entry:
+
+```bash
+aspire integration search postgres
+aspire docs search postgres
+aspire docs get <slug>
+aspire docs api search postgres --language csharp
+aspire docs api get <id>
+aspire add <package>
+```
+
+For dashboard or custom resource commands, use docs for the pattern and API docs for the specific entry:
+
+```bash
+aspire docs search "custom resource commands"
+aspire docs get custom-resource-commands
+aspire docs api search WithCommand --language csharp
+```
+
+Keep these points in mind:
+
+- Read the docs before editing the AppHost so the implementation follows a documented Aspire pattern instead of guessing the workflow.
+- Use `aspire integration list` when the user asks to discover available integrations before changing the AppHost, or `aspire integration search <query>` when the package ID is unknown.
+- Use `aspire docs api` when you need the C# or TypeScript reference entry for the exact API you are about to call.
+- If the AppHost is C# and you need to understand local overloads or builder chains, use the `dotnet-inspect` skill if it is available after checking the Aspire API reference.
+- After adding an integration, restart with `aspire start` so the updated AppHost takes effect.
+
+## Scenario: The AppHost Is TypeScript And Generated APIs Matter
+
+If the AppHost is `apphost.ts`, the `.aspire/modules/` directory contains generated TypeScript modules that expose Aspire APIs.
+
+- Do not edit `.aspire/modules/` directly.
+- Use `aspire add <package>` to regenerate the available APIs when adding integrations.
+- Use `aspire restore` if `.aspire/modules/` disappeared after a pull, clean, or branch switch.
+- Inspect `.aspire/modules/aspire.ts` after regeneration or restore to see the newly available APIs.
+
+## Scenario: I Need Secrets, Deployment, Or A Playwright Handoff
+
+Use `aspire secret` for AppHost user secrets, especially connection strings and passwords:
+
+```bash
+aspire secret set Parameters:postgres-password MySecretValue
+aspire secret list
+```
+
+Use `aspire publish` and `aspire deploy` for full deployment work, or `aspire do <step>` when the user only wants one named pipeline step such as seeding data or pushing containers.
+
+If Playwright CLI is configured in the environment, use Aspire to discover the endpoint first and let Playwright use that discovered URL afterward. When multiple frontends exist or the URL needs to be passed to another tool, prefer `aspire describe --format Json` before the Playwright handoff.

--- a/.agents/skills/aspire-orchestration/references/app-commands.md
+++ b/.agents/skills/aspire-orchestration/references/app-commands.md
@@ -1,0 +1,123 @@
+# App Commands
+
+Use this when the task is about app-level lifecycle, bootstrap, or AppHost-wide maintenance.
+
+## Start The App Safely In The Background
+
+```bash
+aspire start
+aspire start --isolated
+aspire stop
+```
+
+- Use `aspire start` for normal background AppHost execution.
+- In git worktrees or when another local instance may already be running, use `aspire start --isolated`.
+- To restart after AppHost changes, rerun the same start command.
+- Use `aspire stop` when cleanup is explicitly requested, ports/locks need to be released, or you are finished with a started instance that the user did not ask to keep running.
+- Avoid `aspire run` in agent workflows — it blocks the terminal.
+
+### `aspire run` vs `aspire start`
+
+| Command | Mode | Use Case |
+|---------|------|----------|
+| `aspire run` | Foreground (interactive) | Human developer at terminal |
+| `aspire start` | Background (detached) | **AI agents — always prefer** |
+| `aspire run --detach` | Background | Alternative to `aspire start` |
+
+## Create A New Aspire App Or Add Aspire To An Existing App
+
+```bash
+aspire new
+aspire init
+aspire init --language typescript
+```
+
+- Use `aspire new` when creating a brand-new Aspire app from scratch.
+- Use `aspire init` when adding Aspire to an existing application.
+
+## After `aspire init` — Hand Off to `aspireify`
+
+`aspire init` drops a minimal AppHost skeleton + AppHost configuration into the
+repo and installs the **`aspireify`** agent skill alongside it. `aspire init` itself does not
+wire resources, projects, or integrations. Hand off the wiring step to:
+
+1. The in-plugin sibling skill: [`../../aspireify/SKILL.md`](../../aspireify/SKILL.md), or
+2. The project-local `.agents/skills/aspireify/SKILL.md` if `aspire init` installed it
+   (project-local wins — defer to it and warn the user).
+
+The aspireify workflow:
+
+1. **Scan** the repository — discover .NET projects, Node.js apps, Python/Go services, docker-compose files
+2. **Present findings** — confirm with user which services to include
+3. **Wire the AppHost** — add resources using 3-tier API preference:
+   - Tier 1: First-party `Aspire.Hosting.*` (e.g., `AddPostgres`, `AddRedis`, `AddViteApp`, `AddNextJsApp`)
+   - Tier 2: Community Toolkit `CommunityToolkit.Aspire.Hosting.*` (e.g., `AddGolangApp`)
+   - Tier 3: Raw fallbacks (`AddExecutable`, `AddDockerfile`, `AddContainer`)
+4. **Configure dependencies** — ServiceDefaults for .NET, OTel for non-.NET
+5. **Validate** — `aspire start` until all resources are healthy
+
+### Key Init Rules
+
+- **Never install the obsolete Aspire workload** (`dotnet workload install aspire`)
+- **Never change the repo's .NET SDK version** (don't modify root `global.json`)
+- **Never change existing project target frameworks** (older TFMs work with newer AppHost)
+- **Always use `aspire docs search` before writing AppHost code** — don't guess APIs
+- **Never hardcode URLs** — use endpoint references (`WithReference`, `WithEnvironment` with expressions)
+- **Never overwrite existing files** — augment and merge
+- **Adapt the AppHost to the app**, not the other way around
+
+### Init Config: `aspire.config.json`
+
+Read `aspire.config.json` at repo root for init context:
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `appHost.language` | `"typescript/nodejs"` or `"csharp"` | AppHost syntax to use |
+| `appHost.path` | Path to AppHost file/dir | Where to edit |
+
+C# has two sub-modes:
+- **Single-file**: `appHost.path` → `apphost.cs` (uses `#:sdk` directive)
+- **Full project**: `appHost.path` → directory with `.csproj` + `Program.cs`
+
+## Find The Right AppHost Or Refresh AppHost-Wide Support
+
+```bash
+aspire ps
+aspire integration list --format Json
+aspire integration search <query> --format Json
+aspire add <package>
+aspire update --self        # upgrades the Aspire CLI itself (NativeAOT global tool or curl install)
+aspire update               # updates project package references / aspire.config.json
+aspire restore
+```
+
+- Use `aspire ps` first to discover which AppHost is already running.
+- Use `aspire integration list --format Json` and `aspire integration search <query> --format Json` for read-only integration discovery.
+- Use `aspire add <package>` to add integrations and regenerate AppHost APIs when you are ready to mutate the AppHost.
+- Use **`aspire update --self`** to upgrade the Aspire CLI itself — the safe, no-side-effect upgrade path agents can run unattended.
+- Use **`aspire update` (no `--self`)** to refresh AppHost package references and bump pinned versions in `aspire.config.json`. This **modifies project files** — get user approval before running unattended (CI / agent flows).
+- Use `aspire restore` after pulls, cleans, or missing generated files.
+- Use `--apphost <path>` when the workspace has multiple AppHosts. The CLI's global config validates configured AppHost paths to catch typos early.
+
+## Key Rules
+
+- **Never install the obsolete Aspire workload** (`dotnet workload install aspire`). Use `aspire add`, `aspire init`, or `aspire new` instead.
+- **Never edit `.aspire/modules/` directly** in TypeScript AppHosts. Use `aspire add <package>` to regenerate APIs, `aspire restore` if files are missing.
+- For unfamiliar C# AppHost APIs, use `aspire docs search` as primary reference. If the `dotnet-inspect` skill is available, use it to inspect local symbols and overloads — but keep docs as the source of truth.
+- For custom dashboard or resource commands (`WithCommand`), always run `aspire docs search "custom resource commands"` before implementing.
+
+## Look Up API Reference Before Editing AppHost Code
+
+```bash
+aspire docs search <query>
+aspire docs get <slug>
+aspire docs api search <query> --language csharp
+aspire docs api search <query> --language typescript
+aspire docs api list <scope>
+aspire docs api get <id>
+```
+
+- Use `aspire docs search` and `aspire docs get` for workflow guidance and documented patterns.
+- Use `aspire docs api search` when you need the C# or TypeScript API reference entry for a resource builder, extension method, or member.
+- Use `aspire docs api list <scope>` to browse children under a language, package, module, type, or symbol.
+- Always specify `--language csharp` or `--language typescript` to get the correct API surface.

--- a/.agents/skills/aspire-orchestration/references/detection.md
+++ b/.agents/skills/aspire-orchestration/references/detection.md
@@ -1,0 +1,160 @@
+# Detection — Recognizing Aspire Projects
+
+> **Purpose**: How to identify that a project uses Aspire, and which project is the AppHost.
+
+## Detection Signals
+
+### 1. C# AppHost (Definitive — Strongest Signal)
+
+Look for `.csproj` files containing the Aspire AppHost SDK reference:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="10.0.0" />
+  <!-- ... -->
+</Project>
+```
+
+**Detection method**: Search for `Aspire.AppHost.Sdk` in `.csproj` files:
+
+```bash
+grep -rl "Aspire.AppHost.Sdk" --include="*.csproj" .
+```
+
+This is the **definitive signal** — if a `.csproj` contains this SDK reference, it is an Aspire AppHost project. All Aspire CLI commands should target this project's directory.
+
+### 1b. File-Based C# AppHost (Definitive)
+
+Single-file C# AppHosts use `apphost.cs` (or similar `.cs` files) with SDK directives instead of a `.csproj`:
+
+```cs
+#:sdk Aspire.AppHost.Sdk
+#:property IsAspireHost=true
+
+var builder = DistributedApplication.CreateBuilder(args);
+// ...
+```
+
+**Detection method**: Search for `apphost.cs` or `.cs` files containing `#:sdk Aspire.AppHost.Sdk`:
+
+```bash
+find . -name "apphost.cs" -not -path "*/node_modules/*"
+grep -rl "#:sdk Aspire.AppHost.Sdk" --include="*.cs" .
+```
+
+File-based AppHosts are run the same way: `aspire start` (never `dotnet apphost.cs` directly).
+
+### 2. TypeScript AppHost (Definitive)
+
+Look for an `apphost.ts` file in the project:
+
+```bash
+find . -name "apphost.ts" -not -path "*/node_modules/*"
+```
+
+A TypeScript AppHost uses the `@aspire/apphost` package and defines resources programmatically in TypeScript instead of C#.
+
+### 3. `.aspire/modules/` Directory (High Confidence)
+
+Aspire generates a `.aspire/modules/` directory for TypeScript AppHost support files. Its presence strongly indicates an Aspire project:
+
+```bash
+[ -d ".aspire/modules" ] && echo "Aspire project detected"
+```
+
+### 4. `aspire.config.json` Configuration (High Confidence)
+
+Aspire 13.2+ uses a rooted `aspire.config.json` file (replaces legacy `aspire.json`):
+
+```bash
+[ -f "aspire.config.json" ] && echo "Aspire configuration found"
+# Legacy fallback:
+[ -f "aspire.json" ] && echo "Legacy Aspire config found (pre-13.2)"
+```
+
+### 5. `.aspire/` Directory (High Confidence)
+
+The `.aspire/` directory stores Aspire settings and secrets:
+
+```bash
+[ -d ".aspire" ] && echo "Aspire settings directory found"
+```
+
+### 6. Service Defaults References (Medium Confidence)
+
+Projects that reference `Aspire.ServiceDefaults` are Aspire service projects (not the AppHost, but part of an Aspire solution):
+
+```bash
+grep -rl "Aspire.ServiceDefaults" --include="*.csproj" .
+```
+
+This indicates the project is **part of** an Aspire solution, but these are the service projects, not the AppHost. Look for the AppHost SDK reference separately.
+
+---
+
+## Detection Priority
+
+When scanning a repository, check signals in this order:
+
+| Priority | Signal | What It Means |
+|----------|--------|---------------|
+| 1 | `Aspire.AppHost.Sdk` in `.csproj` | This IS the AppHost — target for `aspire start` |
+| 1b | `apphost.cs` or `#:sdk Aspire.AppHost.Sdk` in `.cs` | File-based C# AppHost — target for `aspire start` |
+| 2 | `apphost.ts` file | TypeScript AppHost — target for `aspire start` |
+| 3 | `.aspire/modules/` directory | Aspire project — look for the AppHost |
+| 4 | `aspire.config.json` or `.aspire/` | Aspire project — look for the AppHost |
+| 5 | `Aspire.ServiceDefaults` references | Part of Aspire solution — AppHost is elsewhere |
+
+## Finding the AppHost Directory
+
+The Aspire CLI commands must be run from the correct context. After detecting an Aspire project:
+
+```bash
+# Find the AppHost project directory
+APPHOST_DIR=$(dirname $(grep -rl "Aspire.AppHost.Sdk" --include="*.csproj" .))
+
+# Or for file-based C# AppHost
+APPHOST_FILE=$(find . -name "apphost.cs" -not -path "*/node_modules/*" | head -1)
+
+# Or for TypeScript
+APPHOST_DIR=$(dirname $(find . -name "apphost.ts" -not -path "*/node_modules/*" | head -1))
+```
+
+## Common Project Structures
+
+### Typical C# Aspire Solution
+
+```
+MyApp/
+├── MyApp.AppHost/              ← AppHost (has Aspire.AppHost.Sdk)
+│   ├── MyApp.AppHost.csproj
+│   └── Program.cs
+├── MyApp.ApiService/           ← Service project
+│   └── MyApp.ApiService.csproj
+├── MyApp.Web/                  ← Frontend project
+│   └── MyApp.Web.csproj
+├── MyApp.ServiceDefaults/      ← Shared defaults
+│   └── MyApp.ServiceDefaults.csproj
+├── .aspire/
+│   └── modules/                ← Aspire-generated
+├── aspire.config.json
+└── MyApp.sln
+```
+
+### Typical TypeScript Aspire Project
+
+```
+MyApp/
+├── apphost.ts                  ← TypeScript AppHost
+├── package.json
+├── src/
+│   ├── api/                    ← Service project
+│   └── web/                    ← Frontend project
+├── .aspire/
+│   └── modules/
+└── aspire.config.json
+```
+
+## Non-Aspire Projects
+
+If none of the detection signals are found, this is **not** an Aspire project. Do not apply Aspire-specific rules. Standard .NET commands (`dotnet run`, `dotnet build`) are appropriate for non-Aspire projects.

--- a/.agents/skills/aspire-orchestration/references/resource-management.md
+++ b/.agents/skills/aspire-orchestration/references/resource-management.md
@@ -1,0 +1,38 @@
+# Resource Management
+
+Use this when the task is scoped to one resource or depends on a specific resource becoming healthy.
+
+## Wait For One Resource Before Touching It
+
+```bash
+aspire wait <resource>
+aspire wait <resource> --status up --timeout 60
+```
+
+- Use `aspire wait` before a dependent action when readiness is the blocker.
+- Add `--status` and `--timeout` for explicit readiness conditions.
+- Treat readiness as resource-scoped — a missing ready signal is not a reason to restart the whole AppHost.
+- Use `displayName` from `aspire ps --format Json`, not `name` ([#15842](https://github.com/microsoft/aspire/issues/15842)).
+
+## Fix Or Operate On One Resource Without Bouncing The Whole App
+
+```bash
+aspire resource <resource> start
+aspire resource <resource> stop
+aspire resource <resource> <command>
+```
+
+- Prefer resource-scoped commands when the task doesn't require an AppHost-wide restart.
+- If one resource is wedged, use resource-scoped commands such as `stop`, `start`, or `rebuild` when the resource exposes them before escalating to a full AppHost restart.
+- Use `aspire resource <resource> <command>` when the AppHost exposes resource-specific dashboard or operational commands.
+- If the resource's own framework watch/HMR/debug workflow is already handling the change, do not force an Aspire resource command.
+
+## What Changed Determines the Action
+
+| What Changed | Action | Command |
+|--------------|--------|---------|
+| AppHost project (Program.cs, .csproj) | Full restart | `aspire stop` → edit → `aspire start` |
+| .NET service project (.cs files) | Rebuild/refresh resource if exposed | `aspire resource <name> rebuild` or the resource's IDE/watch workflow |
+| JavaScript/Python/Go files | Usually no Aspire action | File watchers/HMR handle it automatically |
+| Configuration (appsettings.json) | Check first | `aspire describe` then decide |
+| TypeScript AppHost deps | Restore | `aspire restore` |

--- a/.agents/skills/aspire-orchestration/references/safety-guardrails.md
+++ b/.agents/skills/aspire-orchestration/references/safety-guardrails.md
@@ -1,0 +1,272 @@
+# Safety Guardrails — Aspire Agent Rules
+
+> **Purpose**: Detailed explanation of why each guardrail exists, what goes wrong when violated, and how to recover.
+
+## Why These Rules Exist
+
+Issue [#15801](https://github.com/microsoft/aspire/issues/15801) documented 5 specific failures when AI agents work in Aspire projects without guidance. Every rule below directly prevents one or more of these failures.
+
+---
+
+## Rule 1: ALWAYS `aspire start` — NEVER `dotnet run`
+
+### Why `dotnet run` Is Dangerous for AppHosts
+
+The AppHost project is an **orchestrator**, not a regular .NET app. Running it with `dotnet run`:
+
+- **Bypasses the Aspire CLI orchestration layer** — resources don't get managed lifecycle
+- **No dashboard** — the Aspire developer dashboard won't launch
+- **No backchannel** — `aspire wait`, `aspire logs`, `aspire describe` won't work
+- **No resource management** — can't operate on individual resources
+- **Port conflicts** — resources start without coordinated port allocation
+- **No cleanup** — orphaned processes when the host exits
+
+### Correct Pattern
+
+```bash
+# ✅ Start the Aspire app
+aspire start
+
+# ✅ Verify it's running
+aspire ps
+```
+
+### `aspire run` vs `aspire start`
+
+| Command | Mode | Dashboard | Use Case |
+|---------|------|-----------|----------|
+| `aspire run` | Foreground (interactive) | Yes, in terminal | Human developer at terminal |
+| `aspire start` | Background (detached) | No terminal output | **AI agents — always prefer this** |
+| `aspire run --detach` | Background (same as start) | Yes, separate window | Alternative to `aspire start` |
+
+For AI agents, **always use `aspire start`** — it runs in the background and returns control to the agent.
+
+### Recovery If `dotnet run` Was Used
+
+```bash
+# Kill the dotnet process manually (find PID first)
+# Then start correctly:
+aspire start
+```
+
+---
+
+## Rule 2: ALWAYS `aspire wait` — NEVER `curl` Polling
+
+### Why `curl` Polling Is Wrong
+
+Aspire tracks resource readiness internally through health checks, dependency graphs, and startup ordering. Manual HTTP polling:
+
+- **Doesn't know the correct port** — Aspire assigns ports dynamically
+- **Doesn't respect dependency ordering** — a resource may respond to HTTP before its dependencies are ready
+- **Creates false negatives** — health endpoint may not exist or may return 503 during startup
+- **Wastes time** — retry loops with arbitrary delays vs. event-driven readiness
+
+### Correct Pattern
+
+```bash
+# ✅ Wait for a specific resource
+aspire wait apiservice
+
+# ✅ Wait with extended timeout for slow resources
+aspire wait postgres --timeout 120
+
+# ✅ Wait then interact
+aspire wait apiservice && curl $(aspire describe apiservice --format Json | jq -r '.endpoints[0].url')
+```
+
+### Machine-Readable Output
+
+Always use `--format Json` when parsing output programmatically:
+
+```bash
+# ✅ Get resource endpoints as JSON
+aspire describe --format Json
+
+# ❌ Never scrape text output
+aspire describe | grep "http"  # fragile, format may change
+```
+
+---
+
+## Rule 3: Prefer Resource Commands / Watch — NEVER `dotnet build` With Aspire Running
+
+### Why `dotnet build` Causes File-Lock Errors
+
+When Aspire is running, it holds file locks on:
+
+- Output assemblies (`.dll`, `.pdb`) of managed resources
+- Build intermediates in `obj/` directories
+- NuGet package caches being read by running processes
+
+Running `dotnet build` while Aspire holds these locks produces:
+
+```
+error MSB3491: Could not write to output file 'bin/Debug/net10.0/MyService.dll'
+error CS2012: Cannot open 'obj/Debug/net10.0/MyService.dll' for writing
+```
+
+The agent then concludes the project is "un-buildable" — a false conclusion.
+
+### Recovery If `dotnet build` Was Used and Locks Hit
+
+When you see `MSB3491` / `CS2012` / "file in use" / "another process is using":
+
+```bash
+# ✅ Single correct recovery
+aspire stop              # release all Aspire-held locks
+
+# Then EITHER use a resource-scoped command if Aspire is still up + one resource changed:
+aspire resource <name> rebuild
+# OR:
+aspire start             # if AppHost code changed or Aspire was fully stopped
+```
+
+> 🔒 **`aspire stop` is the ONLY first step.** Do not `pkill dotnet`, do not delete
+> `bin/`/`obj/`, do not "reboot to release the lock", and do not tell the user the
+> project has a permanent build failure. The cause is always the same — Aspire is
+> holding the output files — and the fix is always `aspire stop`.
+
+| ❌ NEVER (file-lock recovery) | ✅ ALWAYS |
+|------------------------------|----------|
+| Say the project has a permanent build failure when you see `MSB3491`/`CS2012` | Recognize Aspire is holding locks and run `aspire stop` |
+| `pkill dotnet` / `kill <PID>` | `aspire stop` (clean shutdown via the CLI) |
+| `rm -rf bin obj` to "force" the build | `aspire stop`, then rebuild |
+| Suggest a reboot | `aspire stop` (single command) |
+| Re-run `dotnet build` with Aspire still up | `aspire stop` first; prefer resource commands/watch/HMR/debug workflow |
+
+### What Changed Determines the Action
+
+| What Changed | Action | Command |
+|--------------|--------|---------|
+| AppHost project (Program.cs, .csproj) | Full restart | `aspire stop` → edit → `aspire start` |
+| .NET service project (.cs files) | Rebuild/refresh resource if exposed | `aspire resource <name> rebuild` or the resource's IDE/watch workflow |
+| JavaScript/Python/Go files | Usually no Aspire action | File watchers/HMR handle it automatically |
+| Configuration (appsettings.json) | Check first | `aspire describe` then decide |
+
+---
+
+## Rule 4: Use `aspire stop` For Cleanup — NEVER Leave Unwanted Processes Running
+
+### Why Cleanup Matters
+
+Aspire orchestrates multiple processes (your services, databases, message brokers, etc.). Leaving them running causes:
+
+- **Port conflicts** — next `aspire start` fails because ports are occupied
+- **File locks** — can't build or modify service code
+- **Resource consumption** — databases, Redis, etc. consuming memory
+- **Stale state** — old code running while you've made changes
+- **Orphaned containers** — Docker containers left running
+
+### Correct Pattern
+
+```bash
+# ✅ Stop when cleanup is requested or the user did not ask to keep it running
+aspire stop
+
+# ✅ Verify everything stopped
+aspire ps  # should show no running resources
+```
+
+### Recovery from Orphaned Processes
+
+```bash
+# Check if anything is still running
+aspire ps
+
+# If aspire ps shows nothing but ports are blocked:
+# The previous instance may have crashed. Start fresh:
+aspire start  # will clean up orphaned state
+```
+
+---
+
+## Rule 5: ALWAYS `--format Json` for Machine-Readable Output
+
+### Why JSON Output Matters for Agents
+
+Text output is formatted for humans and may change between versions. JSON output is:
+
+- **Stable** — structured contract unlikely to break
+- **Parseable** — `jq`, Python, or any JSON parser works
+- **Complete** — includes fields not shown in text output
+
+### Examples
+
+```bash
+# ✅ Machine-readable resource list
+aspire ps --format Json
+
+# ✅ Get specific resource details
+aspire describe apiservice --format Json
+
+# ✅ Parse with jq
+aspire describe --format Json | jq '.resources[] | select(.state == "Running")'
+```
+
+### ⚠️ Known JSON Output Issues
+
+| Issue | Workaround |
+|-------|-----------|
+| `aspire start --format json` may emit human-readable text before JSON ([#15843](https://github.com/microsoft/aspire/issues/15843)) | Strip non-JSON lines before parsing |
+| `aspire stop` does NOT support `--format json` yet | Use exit code for success/failure |
+| `aspire ps --format Json` returns `name` and `displayName` fields | Use `displayName` for `aspire wait` — the `name` field may be rejected ([#15842](https://github.com/microsoft/aspire/issues/15842)) |
+
+### Hidden Resources and `--include-hidden`
+
+`aspire ps`, `aspire describe`, and other CLI commands **filter out resources marked as
+hidden in the AppHost** (proxies, helper containers, migration jobs, etc.).
+This filtering is correct for normal workflows — agents and humans see only the resources they
+care about, not the implementation scaffolding.
+
+Use `--include-hidden` when:
+
+| Situation | Why |
+|-----------|-----|
+| Debugging a proxy or sidecar | Proxies are hidden by default; you need their state to diagnose connectivity |
+| Investigating helper containers | Helper containers (e.g. wait-for-it shims, init containers) are hidden |
+| Tracking down migration jobs | Migration / seed jobs are typically hidden once they finish |
+| Expected resources are missing from `aspire ps` | The resource may exist but be marked hidden — confirm with `--include-hidden` before assuming the AppHost is wrong |
+| Parsing for completeness in agent automation | A full-graph view requires explicit opt-in |
+
+```bash
+# ✅ Normal flow — filtered (correct for most tasks)
+aspire ps --format Json
+
+# ✅ Debugging / completeness — include hidden resources
+aspire ps --include-hidden --format Json
+aspire describe --include-hidden --format Json
+```
+
+If a user reports "I can't see my proxy / migration / helper container," reach for
+`--include-hidden` before assuming the AppHost is misconfigured.
+
+---
+
+## Rule 6: ALWAYS `--non-interactive` for Agent Commands
+
+### Why It Matters
+
+AI agents run in non-interactive terminals. Some Aspire CLI commands may prompt for confirmation or input. Always pass `--non-interactive` to prevent hangs:
+
+```bash
+# ✅ Agent-safe commands
+aspire start --non-interactive
+aspire deploy --non-interactive
+aspire agent init --non-interactive
+```
+
+> ⚠️ **Known issue**: `aspire agent init --non-interactive` is broken in some versions ([#16264](https://github.com/microsoft/aspire/issues/16264), [#15071](https://github.com/microsoft/aspire/issues/15071)). If it fails, instruct the user to run it from a standard terminal.
+
+---
+
+## Recovery Patterns Summary
+
+| Mistake Made | Recovery Steps |
+|-------------|---------------|
+| Used `dotnet run` on AppHost | Kill the process, run `aspire start` |
+| Used `dotnet build` and got file locks | `aspire stop`, wait 2s, then `dotnet build` or `aspire start` |
+| Used `curl` polling and got false results | `aspire wait <resource>`, then use endpoints from `aspire describe` |
+| Left Aspire running, now ports conflict | `aspire stop`, then `aspire start` |
+| Resource won't start after code change | Fix code, then use resource commands/watch/HMR/debug workflow or restart the AppHost if the AppHost model changed |
+| Nothing works, environment broken | `aspire doctor` to diagnose, then follow recommendations |

--- a/.agents/skills/aspire/SKILL.md
+++ b/.agents/skills/aspire/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: aspire
+description: >-
+  **WORKFLOW SKILL** - Top-level router for Aspire 13.4 distributed apps. Detects the
+  AppHost, enforces safety guardrails, and routes to the right sub-skill.
+  USE FOR: Aspire AppHost detected, aspire CLI, distributed app, cloud-native .NET,
+  aspire start, aspire stop, aspire resource, aspire deploy, aspire destroy, aspire publish,
+  aspire init, aspire new, aspire add, aspire integration list/search, aspire wait,
+  aspire describe, aspire ps, aspire dashboard run, aspire doctor, aspire update,
+  aspire logs, aspire otel, --include-hidden, aspireify, WithBrowserLogs, custom
+  dashboard/resource commands, .aspire/modules recovery, Playwright URL discovery.
+  DO NOT USE FOR: non-Aspire .NET projects (use dotnet directly), Azure provisioning
+  without Aspire (use azure-prepare), container-only repos with no AppHost, ordinary
+  build/test tasks.
+  INVOKES: aspire-init, aspireify, aspire-orchestration, aspire-deployment, aspire-monitoring.
+  FOR SINGLE OPERATIONS: Route directly to the matching sub-skill.
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.1"
+---
+
+# Aspire
+
+Use this skill when the task involves an Aspire distributed application — operating the
+AppHost or its resources through the Aspire CLI rather than falling back to ad-hoc `dotnet`,
+`docker`, or shell workflows.
+
+## Detection
+
+Activate when ANY signal is present. Use the **Scope** column to decide whether to route to
+the bootstrap skills (`aspire-init` / `aspireify`) or to a runtime sub-skill:
+
+| Signal | How to Detect | Confidence | Scope |
+|--------|---------------|------------|-------|
+| C# AppHost | `.csproj` containing `Aspire.AppHost.Sdk` | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
+| File-based C# AppHost | `apphost.cs` with `#:sdk Aspire.AppHost.Sdk` | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
+| TypeScript AppHost | `apphost.ts` file in project | ✅ Definitive | AppHost present → orchestration / deployment / monitoring |
+| Aspire config without AppHost | `aspire.config.json` present **and no AppHost** above | High | Bootstrap → `aspireify` (skeleton dropped, needs wiring) |
+| Aspire config with AppHost | `aspire.config.json` present **and** AppHost above | High | AppHost present → orchestration / deployment / monitoring |
+| Aspire settings | `.aspire/` directory present | High | AppHost present (usually) |
+| Generated TS modules | `.aspire/modules/` directory present | High | AppHost present (TS) |
+| Service defaults | `Aspire.ServiceDefaults` in project references | Medium | AppHost present |
+| **No AppHost, no `aspire.config.json`** | None of the above and user asks to add Aspire | n/a | Bootstrap → `aspire-init` (skeleton drop) |
+
+## Default Workflow
+
+0. **Bootstrap branch** — if **no AppHost exists** in the repo, route to
+   [`aspire-init`](../aspire-init/SKILL.md) for the skeleton drop. If an AppHost stub exists
+   but is **unwired** (no resources declared), route to [`aspireify`](../aspireify/SKILL.md).
+   Only continue with the steps below once a wired AppHost is present.
+1. Confirm workspace is Aspire — identify the AppHost
+2. `aspire start` (or `aspire start --isolated` in worktrees or whenever shared local state is risky)
+3. `aspire wait <resource>` before interacting with any resource
+4. Inspect state with `aspire describe`, `aspire otel logs`, `aspire logs`, `aspire otel traces`, and `aspire export` before making code changes
+5. Before adding integrations, use `aspire integration search <query>` when the package is unknown, then `aspire add <package>` when ready to mutate the AppHost
+6. When code changes, decide whether the AppHost model changed or only one resource changed. Re-run `aspire start` after AppHost changes; otherwise prefer resource commands, runtime watch/HMR, dashboard actions, or IDE-managed debugging as appropriate.
+
+## Key Rules
+
+- **Always** `aspire start`, **never** `dotnet run` on AppHosts
+- **Always** `aspire wait <resource>`, **never** manual HTTP polling
+- Use `aspire resource <resource-name> <command>` for resource operations such as `stop`, `start`, or `rebuild` when available
+- Do not stop or restart the whole AppHost just because one resource changed
+- Use `features.defaultWatchEnabled` only for Aspire default watch; do not treat it as per-resource rebuild, restart, or hot reload
+- Prefer a resource's own framework/runtime hot reload, HMR, or watch workflow when it already handles the change
+- **Always** `aspire docs search <topic>` before editing unfamiliar AppHost APIs
+- **Always** `aspire docs api search <query> --language csharp|typescript` for API reference before editing AppHost code
+- **Always** `--non-interactive` for agent execution
+- Use `aspire integration list --format Json` and `aspire integration search <query> --format Json` for read-only integration discovery
+- **Never** install the obsolete Aspire workload
+- **Never** edit `.aspire/modules/` directly in TypeScript AppHosts
+
+## Routing
+
+| Task | Route To |
+|------|----------|
+| Start, stop, wait, restart, rebuild | → [aspire-orchestration](../aspire-orchestration/SKILL.md) |
+| Create a new Aspire project from a template (`aspire new`) | → [aspire-init](../aspire-init/SKILL.md) (in-plugin) |
+| Add Aspire to an existing repo (`aspire init`, drop skeleton) | → [aspire-init](../aspire-init/SKILL.md) (in-plugin) |
+| Wire AppHost / scaffold resource graph / add integrations after `aspire init` | → [aspireify](../aspireify/SKILL.md) (in-plugin) |
+| Deploy, publish, destroy, pipeline steps | → [aspire-deployment](../aspire-deployment/SKILL.md) |
+| Logs, traces, metrics, dashboard, browser logs | → [aspire-monitoring](../aspire-monitoring/SKILL.md) |
+| Deployed app monitoring (Azure) | → `azure-diagnostics` skill (azure-skills plugin) |
+
+## Sub-Skills
+
+### aspire-init
+First-run flow only. Owns the skeleton drop for repos that do **not** yet have an AppHost —
+picks `aspire new <template>` (greenfield) or `aspire init` (existing repo), runs the CLI,
+and hands off to `aspireify` for the actual wiring. Self-deactivates once the skeleton is in
+place. Do **not** use it on a repo that already contains an AppHost.
+
+### aspireify
+Agentic AppHost wiring after `aspire init` lands the skeleton. Scans the repo, proposes a
+resource graph (Postgres / Redis / Rabbit / etc.), edits the AppHost (C#, file-based C#, or
+TypeScript), wires `Aspire.ServiceDefaults` + OTel, validates with `aspire start`, then
+self-deactivates. Owns current AppHost authoring patterns (`AddNextJsApp`, `AddViteApp`,
+`WithBrowserLogs()`, generated `.aspire/modules/`, unified TS `withEnvironment`,
+endpoint references, and config/secret migration).
+
+### aspire-orchestration
+Lifecycle management: start, stop, wait, resource commands, default watch/HMR guidance, and file-lock recovery.
+Safety guardrails that prevent agent self-harm. Owns `aspire ps` / `aspire describe` /
+`--include-hidden` inspection and CLI upgrades (`aspire update --self`). Does **not** edit
+AppHost code — defers to `aspireify` for wiring.
+
+### aspire-deployment
+Multi-target deployment and tear-down: `aspire deploy`, `aspire publish`, `aspire destroy`,
+`aspire do <step>`. Targets: Azure Container Apps, App Service, AKS, Kubernetes (Helm),
+Docker Compose. Owns current deployment surfaces (Front Door, NSP, AKS hosting, Foundry
+`AddPromptAgent`, JS `PublishAs*`, `--pipeline-log-level`) and 13.4 API naming.
+
+### aspire-monitoring
+Observability: `aspire logs`, `aspire otel`, `aspire describe`, `aspire export`,
+`aspire dashboard run`. Routes between local Aspire CLI diagnostics, AKS workload tooling,
+and deployed-Azure platform tools. Surfaces dashboard features (notification center,
+Rebuild command, browser-logs telemetry).
+
+## Project-Local Skill Override
+
+If any of the following exist project-locally (from `aspire agent init` or Aspire
+`aspire init`), **warn the user** and **defer to the project-local copy** — repo-specific
+guidance there should not be overridden by the in-plugin sibling:
+
+| Project-local file | Precedence |
+|--------------------|-----------|
+| `.agents/skills/aspire/SKILL.md` | This file (top-level router) defers to it for deeper C# / TS AppHost editing, Playwright handoff, investigation workflows. |
+| `.agents/skills/aspireify/SKILL.md` | The in-plugin `aspireify` sibling defers to it for AppHost wiring. |
+| `.agents/skills/aspire-init/SKILL.md` | The in-plugin `aspire-init` sibling defers to it for the skeleton/first-run flow. |
+
+**Safety guardrails from this plugin always apply** even when project-local skills are
+active.
+
+## Prerequisites
+
+| Requirement | Install |
+|-------------|---------|
+| .NET 10.0 SDK | https://dotnet.microsoft.com/download |
+| Aspire CLI (curl/PowerShell) | `curl -sSL https://aspire.dev/install.sh \| bash` |
+| Aspire CLI (NativeAOT global tool, .NET 10) | `dotnet tool install -g Aspire.Cli` |
+
+Either install method works. The `dotnet tool install` path produces a NativeAOT binary
+(instant startup, no JIT warmup) and is recommended when .NET 10 is already present.
+
+## References
+
+- [aspire-13-3-breaking-changes.md](references/aspire-13-3-breaking-changes.md) — Every 13.3
+  breaking change to scrub from agent-generated code, scripts, and CI snippets (rename of
+  `--log-level`, dashboard MCP removal, `NameOutput` → `NameOutputReference`,
+  `AddAndPublishPromptAgent` removal, TS `withEnvironment*` deprecation, and the full
+  13.2 → 13.3 migration checklist).
+- [../aspire-orchestration/references/agent-workflows.md](../aspire-orchestration/references/agent-workflows.md) — Common agent workflows: worktrees, code changes, investigation, integrations, TypeScript generated APIs, secrets, deployment, and Playwright handoff.
+- [../aspire-orchestration/references/app-commands.md](../aspire-orchestration/references/app-commands.md) — App lifecycle, bootstrap, update, restore, docs, and integration discovery commands.
+- [../aspire-orchestration/references/resource-management.md](../aspire-orchestration/references/resource-management.md) — Resource wait and resource-command guidance.
+- [../aspire-monitoring/references/monitoring.md](../aspire-monitoring/references/monitoring.md) — App state, logs, traces, search filtering, dashboard links, and export workflows.
+- [../aspire-monitoring/references/playwright-handoff.md](../aspire-monitoring/references/playwright-handoff.md) — Playwright handoff after Aspire endpoint discovery.
+- [../aspire-deployment/SKILL.md](../aspire-deployment/SKILL.md) — Deployment and pipeline-step workflows.
+- [../aspireify/references/apphost-wiring.md](../aspireify/references/apphost-wiring.md) — C# and TypeScript AppHost API lookup and wiring patterns.

--- a/.agents/skills/aspire/references/aspire-13-3-breaking-changes.md
+++ b/.agents/skills/aspire/references/aspire-13-3-breaking-changes.md
@@ -1,0 +1,110 @@
+# Aspire 13.3 Breaking Changes — Agent Reference
+
+Single, agent-facing scrub list of every 13.3 breaking change that may affect agent-generated
+code, scripts, CI snippets, or skill routing. Source:
+[Aspire 13.3 release notes](https://aspire.dev/whats-new/aspire-13-3/).
+
+> Use this page when reviewing AppHost code, CI YAML, or shell snippets for 13.3 compatibility.
+> Agents must scrub for these patterns before recommending or generating code.
+
+## Quick scrub table
+
+| Change | Migration |
+|--------|-----------|
+| `--log-level` → `--pipeline-log-level` on `aspire publish` / `aspire deploy` | Update CI/CD scripts to use `--pipeline-log-level <level>`. |
+| Dashboard MCP server **removed** along with `ASPIRE_DASHBOARD_MCP_ENDPOINT_URL` | Use AppHost-level MCP via `aspire agent init`. See [Dashboard MCP migration](#dashboard-mcp-migration). |
+| `NameOutput` → `NameOutputReference` (Azure Network resources) | Replace every `*.NameOutput` with `*.NameOutputReference`. |
+| `OtlpEndpointEnvironmentVariableName` property removed | Remove the property; OTLP endpoint env var is managed automatically. |
+| `AksSkuTier` enum removed | Delete the reference. AKS control-plane defaults to **Free** SKU. |
+| `AddAndPublishPromptAgent` API removed | Use `AddPromptAgent` — returns a working `AzurePromptAgentResource`. |
+| Kubernetes Ingress / Gateway routing types moved namespaces | Update `using` directives where these types are referenced directly. |
+| `package.json` `engines.node` no longer drives Node image selection | Pin Node version explicitly via `WithDockerfile` or your Dockerfile base image. |
+| `dotnet new aspire-py-starter` removed | Use `aspire new aspire-py-starter` (template moved to Aspire CLI; .NET SDK no longer required). |
+| TypeScript per-kind `withEnvironment*` helpers `@deprecated` | Use unified `withEnvironment(name, value)`. See [TS withEnvironment migration](#typescript-withenvironment-migration). |
+| CLI telemetry `--format json` schema aligned with MCP tool format | Update parsers consuming `--format json` from telemetry commands. |
+| `ASPIREEXTENSION001` JS diagnostic ID renamed to `ASPIREJAVASCRIPT001` | Update `#pragma warning disable` and any code-search rules. |
+| Docker Swarm `UpdateConfig` property types changed | Update generated/hand-written Swarm overrides. |
+| `aspire init` no longer wires up the AppHost | Follow with `aspireify` (in-plugin sibling skill or project-local copy). |
+| In-dashboard GitHub Copilot UI removed | Replaced by `aspire agent init`-driven agentic flow (works with Copilot, Claude, Cursor, any MCP/skill agent). |
+
+## TypeScript `withEnvironment` migration
+
+Per-kind helpers are still generated for backward compatibility but marked `@deprecated` and
+slated for removal. Replace every call site with the unified API.
+
+| Old method (deprecated)                              | Replacement                          |
+|------------------------------------------------------|--------------------------------------|
+| `withEnvironmentExpression(name, expr)`              | `withEnvironment(name, expr)`        |
+| `withEnvironmentEndpoint(name, endpoint)`            | `withEnvironment(name, endpoint)`    |
+| `withEnvironmentParameter(name, param)`              | `withEnvironment(name, param)`       |
+| `withEnvironmentConnectionString(name, resource)`    | `withEnvironment(name, resource)`    |
+| `withEnvironmentFromOutput(name, output)`            | `withEnvironment(name, output)`      |
+| `withEnvironmentFromKeyVaultSecret(name, secret)`    | `withEnvironment(name, secret)`      |
+
+The unified `withEnvironment(name, value)` accepts any of: a plain `string`,
+`ReferenceExpression`, `EndpointReference`, parameter builder, connection string resource
+builder, or `IExpressionValue` — one method handles every value kind.
+
+## Dashboard MCP migration
+
+The Aspire dashboard no longer hosts an MCP server, and the
+`ASPIRE_DASHBOARD_MCP_ENDPOINT_URL` environment variable has been removed. AI coding agents
+now connect to your Aspire app through an **AppHost-level MCP server** plus skills wired up by
+`aspire agent init`.
+
+```bash
+# Replace any prior dashboard-MCP setup with:
+aspire agent init
+```
+
+Detection covers GitHub Copilot, Claude, Cursor, and any other agent that supports skills or
+MCP. The previous in-dashboard GitHub Copilot UI has been removed in favor of this flow.
+
+If a script or environment file still sets `ASPIRE_DASHBOARD_MCP_ENDPOINT_URL`, delete it.
+
+## `aspire init` no longer wires the AppHost
+
+In 13.3, `aspire init` drops a skeleton (`aspire.config.json` + AppHost stub) and installs the
+`aspireify` agent skill, but does **not** wire resources, projects, or integrations on its own.
+
+Workflow:
+
+1. `aspire init --language csharp|typescript --non-interactive`
+2. Hand off to the `aspireify` skill (in-plugin sibling or project-local
+   `.agents/skills/aspireify/SKILL.md`) to scan the repo, propose a resource graph, edit the
+   AppHost, wire `Aspire.ServiceDefaults` + OTel, and validate via `aspire start`.
+
+Skills shipped in this plugin:
+
+- `aspire-init` — owns the skeleton drop and template choice.
+- `aspireify` — owns the wiring step after the skeleton lands.
+
+## Migration from Aspire 13.2 to 13.3
+
+Mirror of the upstream checklist plus the items above. Run through each step before
+recommending Aspire-related changes against an existing repo.
+
+1. **Update the CLI** — `aspire update --self`.
+2. **Update your projects** — `aspire update` from the repo root (modifies project package
+   references; get user approval before running in CI).
+3. **Audit `--log-level` usage** in CI/CD pipelines and rename to `--pipeline-log-level`.
+4. **Search for breaking-change identifiers** in AppHost code:
+   - `NameOutput` → `NameOutputReference`
+   - `AddAndPublishPromptAgent` → `AddPromptAgent`
+   - `AksSkuTier` → delete (defaults to Free)
+   - `OtlpEndpointEnvironmentVariableName` → delete
+   - `ASPIREEXTENSION001` → `ASPIREJAVASCRIPT001`
+5. **Replace `dotnet new aspire-py-starter`** with `aspire new aspire-py-starter`.
+6. **Rerun `aspire agent init`** if you previously relied on the dashboard MCP server or its
+   `ASPIRE_DASHBOARD_MCP_ENDPOINT_URL` env var.
+7. **Re-pin Node versions** in Dockerfiles if you were relying on `package.json`
+   `engines.node` for base-image selection.
+8. **Rewire AppHost via `aspireify`** if the repo went through `aspire init` on 13.3 — the
+   skeleton is unwired by design.
+9. **Replace deprecated TS `withEnvironment*` helpers** with the unified
+   `withEnvironment(name, value)` (see [migration table](#typescript-withenvironment-migration)).
+10. **Update Kubernetes Ingress / Gateway `using` directives** if your AppHost references the
+    moved types directly.
+11. **Update consumers of `--format json`** from CLI telemetry commands to the new
+    MCP-aligned schema.
+12. **Update Docker Swarm overrides** for the new `UpdateConfig` property types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Service Bus Viewer Version History
 
+## 0.47.0 (2026-08-23)
+
+- **Added:** Optional **To**, **Reply To**, **Subject**, and **Partition Key** fields in the Send Message window, with the values sent on the outgoing message and displayed in received and expanded peeked message details.
+- **Added:** **Advanced** toggle in the Send Message header that shows or hides the new fields; the choice is saved in a browser cookie and defaults to off.
+- **Changed:** The Peeked Messages table shows the partition key as a sub-value under the entity name for partitioned queues and topics.
+- **Changed:** Renamed the **Application Properties** section in the send and receive views to **Custom Properties**.
+- **Changed:** The Aspire AppHost and the `SolidCode.Aspire.Hosting.ServiceBusViewer` support library are now built against Aspire 13.5.2.
+- **Changed:** The `SolidCode.Aspire.Hosting.ServiceBusViewer` package version is now aligned with the Aspire version it targets, and future releases will continue to carry the same version number as their target Aspire release.
+- **Changed:** Paste From Clipboard now skips the **Diagnostic-Id** application property when loading a copied message into the send window.
+- **Fixed:** The duplicate-detection warning for the Message ID field is now always visible with its icon and text on entities with duplicate detection enabled, instead of appearing only after a paste.
+- **Fixed:** The "Duplicate detection enabled" indicator in the Send Message window no longer mixes information and warning semantics. It shows as a neutral info notice when duplicate detection is enabled, and the amber warning styling applies to the indicator and Message ID field only when the warning is armed with a non-empty Message ID.
+- **Fixed:** The Payload editor in the Send Message window now stretches to match the adjacent properties column.
+- **Fixed:** Sending a message with a Scheduled Enqueue Time or Time to Live that cannot be parsed now returns a validation error instead of silently dropping the property.
+- **Fixed:** The Partition Key in the Send Message window is now limited to 128 characters with client-side and API validation, matching the Azure Service Bus limit.
+- **Fixed:** A number of additional minor bugs, with small usability and display improvements.
+
 ## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The repository also includes the `SolidCode.Aspire.Hosting.ServiceBusViewer` Asp
 - Peek and receive messages from queues or topic subscriptions, including session-enabled entities.
 - View message bodies, system properties, and application properties, with client-side JSON formatting.
 - Copy a received or peeked message body as plain text, or copy the full message as JSON including system and application properties.
-- Send messages to queues or topics with system and typed application properties.
+- Send messages to queues or topics with system properties and typed application properties.
 
 ## Run with Docker
 
@@ -61,7 +61,9 @@ docker run --name ServiceBusViewer -p 8080:8080 `
 ## Accessing the Service Bus Emulator
 
 - Use `localhost` when the viewer runs on the same host as the emulator.
-- Use `host.docker.internal` when a containerized viewer needs to reach an emulator running on the host.
+- Docker: use `host.docker.internal` to reach an emulator running on the Docker host.
+- Podman: use `host.docker.internal` or `host.containers.internal` to reach an emulator running on the Podman host. 
+  - IMPORTANT: The host emulator must listen on a non-loopback interface (not just `127.0.0.1`) to be reachable from Podman containers.
 - Use the emulator container or compose service name when both are running on the same container network.
 - For a real Azure Service Bus namespace, use an appropriate namespace connection string from the Azure portal.
 
@@ -92,6 +94,20 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
+## 0.47.0 (2026-08-23)
+
+- **Added:** Optional To, Reply To, Subject, and Partition Key fields in the Send Message window, with the values sent on the outgoing message and displayed in received and expanded peeked message details.
+- **Added:** Advanced toggle in the Send Message header that shows or hides the new fields; the choice is saved in a browser cookie and defaults to off.
+- **Changed:** The Peeked Messages table shows the partition key as a sub-value under the entity name for partitioned queues and topics.
+- **Changed:** The Aspire AppHost and the `SolidCode.Aspire.Hosting.ServiceBusViewer` support library are now built against Aspire 13.5.2.
+- **Changed:** The `SolidCode.Aspire.Hosting.ServiceBusViewer` package version is now aligned with the Aspire version it targets, and future releases will continue to carry the same version number as their target Aspire release.
+- **Changed:** Paste From Clipboard now skips the Diagnostic-Id application property when loading a copied message into the send window.
+- **Changed:** The duplicate-detection warning for the Message ID field is now always visible with its icon and text on entities with duplicate detection enabled, instead of appearing only after a paste.
+- **Fixed:** The "Duplicate detection enabled" indicator in the Send Message window no longer mixes information and warning semantics. It shows as a neutral info notice when duplicate detection is enabled, and the amber warning styling applies to the indicator and Message ID field only when the warning is armed with a non-empty Message ID.
+- **Fixed:** Sending a message with a Scheduled Enqueue Time or Time to Live that cannot be parsed now returns a validation error instead of silently dropping the property.
+- **Fixed:** The Partition Key in the Send Message window is now limited to 128 characters with client-side and API validation, matching the Azure Service Bus limit.
+- **Fixed:** A number of additional minor bugs, with small usability and display improvements.
+
 ## 0.45.0 (2026-08-20)
 
 - **Added:** Full-message JSON copy button for received and peeked messages that copies the message body, system properties, and application properties as valid JSON, alongside the existing body-only copy action.
@@ -110,15 +126,6 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 - **Fixed:** A failed message peek while selecting an entity no longer changes the browser session's selected entity or messages.
 - **Fixed:** Successful sends and receives are no longer reported as failures when the following message-list refresh fails.
 
-## 0.40.0 (2026-08-12)
-
-- **Breaking:** Renamed runtime configuration to `SERVICEBUSVIEWER_CONNECTION_STRING`, `SERVICEBUSVIEWER_EMULATOR_MANAGEMENT_CONNECTION_STRING`, `SERVICEBUSVIEWER_QUEUE_OR_TOPIC_NAME`, and `SERVICEBUSVIEWER_SUBSCRIPTION_NAME` with no legacy aliases.
-- **Added:** An entity sidebar filter with debounced input, immediate application on Enter, and state preserved between viewer and entity details pages.
-- **Changed:** Unified Azure connection handling so one Manage-capable connection string is used for entity discovery and message operations, with automatic fallback to direct entity access when management is unauthorized.
-- **Changed:** Reserved the optional second connection string for emulator management and renamed it to **Emulator Management Connection String** throughout the API and UI.
-- **Fixed:** Failed connection attempts during initial message peeking no longer leave the browser session marked as connected, allowing immediate retry with corrected credentials.
-- **Fixed:** A queue, topic, or subscription supplied with a management-capable connection is retained as the initial viewer selection.
-- **Fixed:** Long expanded message bodies increasing the width of the Peeked Messages table.
 
 See the [full changelog](CHANGELOG.md) for the complete version history.
 

--- a/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
+++ b/src/ServiceBusViewer.AppHost/ServiceBusViewer.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.5.0">
+<Project Sdk="Aspire.AppHost.Sdk/13.5.2">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -17,8 +17,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.0" />
-		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.0" />
+		<PackageReference Include="Aspire.Hosting.JavaScript" Version="13.5.2" />
+		<PackageReference Include="Aspire.Hosting.Azure.ServiceBus" Version="13.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ServiceBusViewer.Web/src/components/common/CopyButton.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/CopyButton.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { cx } from '../../lib/cx';
+
+interface CopyButtonProps {
+	text: string | null | undefined;
+	label: string;
+	icon: string;
+	copiedText?: string;
+	ariaLabel?: string;
+	disabled?: boolean;
+	disabledTitle?: string;
+	className?: string;
+}
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+export function CopyButton({
+	text,
+	label,
+	icon,
+	copiedText = 'Copied',
+	ariaLabel,
+	disabled = false,
+	disabledTitle,
+	className,
+}: CopyButtonProps) {
+	const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+
+	useEffect(() => {
+		if (copyStatus === 'idle') {
+			return undefined;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			setCopyStatus('idle');
+		}, 2000);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [copyStatus]);
+
+	const handleClick = async () => {
+		if (text === null || text === undefined || !navigator.clipboard?.writeText) {
+			setCopyStatus('failed');
+			return;
+		}
+
+		try {
+			await navigator.clipboard.writeText(text);
+			setCopyStatus('copied');
+		} catch {
+			setCopyStatus('failed');
+		}
+	};
+
+	const isDisabled = disabled || text === null || text === undefined;
+	const isBusy = copyStatus !== 'idle';
+
+	return (
+		<button
+			type="button"
+			disabled={isDisabled}
+			className={cx(
+				'relative inline-flex h-8 items-center justify-center overflow-hidden rounded-lg border text-[11px] font-medium transition-all duration-200',
+				isDisabled
+					? 'cursor-not-allowed border-slate-200 bg-slate-50 text-slate-400 dark:border-slate-800 dark:bg-slate-950/40 dark:text-slate-600'
+					: copyStatus === 'copied'
+						? 'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-400'
+						: copyStatus === 'failed'
+							? 'border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-400'
+							: 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800',
+				className,
+			)}
+			onClick={handleClick}
+			aria-label={ariaLabel ?? `Copy ${label.toLowerCase()}`}
+			title={isDisabled ? (disabledTitle ?? ariaLabel ?? `Copy ${label.toLowerCase()}`) : (ariaLabel ?? `Copy ${label.toLowerCase()}`)}
+		>
+			<span
+				className={cx(
+					'flex items-center gap-1.5 transition-all duration-200',
+					isBusy ? '-translate-y-1 opacity-0' : 'translate-y-0 opacity-100',
+				)}
+			>
+				<span className="material-icons-round text-sm" aria-hidden="true">
+					{icon}
+				</span>
+				<span>{label}</span>
+			</span>
+			<span
+				aria-live="polite"
+				className={cx(
+					'absolute inset-0 flex items-center justify-center transition-all duration-200',
+					isBusy ? 'translate-y-0 opacity-100' : 'translate-y-1 opacity-0',
+				)}
+			>
+				{copyStatus === 'copied' ? copiedText : 'Copy failed'}
+			</span>
+		</button>
+	);
+}

--- a/src/ServiceBusViewer.Web/src/components/common/CopyFullMessageButton.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/CopyFullMessageButton.tsx
@@ -1,0 +1,25 @@
+import { buildFullMessageJson } from '../../lib/messageJson';
+import { cx } from '../../lib/cx';
+import { CopyButton } from './CopyButton';
+import type { ReceivedMessageDto } from '../../types/serviceBus';
+
+interface CopyFullMessageButtonProps {
+	message?: ReceivedMessageDto | null;
+	disabled?: boolean;
+	className?: string;
+}
+
+export function CopyFullMessageButton({ message, disabled = false, className }: CopyFullMessageButtonProps) {
+	return (
+		<CopyButton
+			text={message ? buildFullMessageJson(message) : null}
+			label="Copy as JSON"
+			icon="data_object"
+			copiedText="JSON copied"
+			ariaLabel="Copy full message as JSON"
+			disabled={disabled || !message}
+			disabledTitle="Receive a message first to copy it as JSON"
+			className={cx('min-w-[132px] px-2.5', className)}
+		/>
+	);
+}

--- a/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
+++ b/src/ServiceBusViewer.Web/src/components/common/JsonMessageBody.tsx
@@ -1,68 +1,21 @@
 import { useEffect, useMemo, useState } from 'react';
-import { buildFullMessageJson } from '../../lib/messageJson';
 import { cx } from '../../lib/cx';
 import { tryFormatJsonBody } from '../../lib/jsonFormatting';
-import type { ReceivedMessageDto } from '../../types/serviceBus';
+import { CopyButton } from './CopyButton';
 
 interface JsonMessageBodyProps {
-  body: string;
-  fullMessage?: ReceivedMessageDto;
-  className?: string;
+	body: string;
+	className?: string;
 }
 
-type CopyStatus = 'idle' | 'copied' | 'copied-json' | 'failed';
 
-const iconButtonClassName =
-  'inline-flex h-8 w-8 items-center justify-center rounded-lg border border-slate-200 bg-white text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800';
-
-export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBodyProps) {
+export function JsonMessageBody({ body, className }: JsonMessageBodyProps) {
   const formattedJson = useMemo(() => tryFormatJsonBody(body), [body]);
   const [isFormatted, setIsFormatted] = useState(Boolean(formattedJson));
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
 
   useEffect(() => {
     setIsFormatted(Boolean(formattedJson));
   }, [formattedJson]);
-
-  useEffect(() => {
-    if (copyStatus === 'idle') {
-      return undefined;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      setCopyStatus('idle');
-    }, 2000);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [copyStatus]);
-
-  const copyText = async (text: string, successStatus: 'copied' | 'copied-json'): Promise<void> => {
-    if (!navigator.clipboard?.writeText) {
-      setCopyStatus('failed');
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopyStatus(successStatus);
-    } catch {
-      setCopyStatus('failed');
-    }
-  };
-
-  const handleCopyClick = async () => {
-    await copyText(body, 'copied');
-  };
-
-  const handleFullCopyClick = async () => {
-    if (!fullMessage) {
-      return;
-    }
-
-    await copyText(buildFullMessageJson(fullMessage), 'copied-json');
-  };
 
   return (
     <div className={cx('js-message-container', className)}>
@@ -71,61 +24,33 @@ export function JsonMessageBody({ body, fullMessage, className }: JsonMessageBod
           Message Body
         </h3>
         <div className="flex items-center gap-2">
-          <span
-            aria-live="polite"
-            className={cx(
-              'text-[11px] font-medium',
-              (copyStatus === 'copied' || copyStatus === 'copied-json') &&
-                'text-emerald-600 dark:text-emerald-400',
-              copyStatus === 'failed' && 'text-rose-600 dark:text-rose-400',
-            )}
-          >
-            {copyStatus === 'copied'
-              ? 'Copied'
-              : copyStatus === 'copied-json'
-                ? 'Copied JSON'
-                : copyStatus === 'failed'
-                  ? 'Copy failed'
-                  : null}
-          </span>
-          {fullMessage ? (
-            <button
-              type="button"
-              className={iconButtonClassName}
-              onClick={handleFullCopyClick}
-              aria-label="Copy full message as JSON"
-              title="Copy full message as JSON"
-            >
-              <span className="material-icons-round text-sm" aria-hidden="true">
-                data_object
-              </span>
-            </button>
-          ) : null}
+          <CopyButton
+            text={body}
+            label="Copy body"
+            icon="content_copy"
+            className="min-w-[104px] px-3"
+          />
           <button
             type="button"
-            className={cx(iconButtonClassName, 'ml-2')}
-            onClick={handleCopyClick}
-            aria-label="Copy message body"
-            title="Copy message body"
-          >
-            <span className="material-icons-round text-sm" aria-hidden="true">
-              content_copy
-            </span>
-          </button>
-          <button
-            type="button"
+            disabled={!formattedJson}
             className={cx(
-              'js-json-toggle inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800',
-              formattedJson && 'js-json-toggle-visible',
+              'inline-flex min-w-[88px] items-center justify-center gap-2 whitespace-nowrap rounded-lg border px-3 py-1.5 text-xs font-medium transition',
+              formattedJson
+                ? 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-slate-700 dark:hover:bg-slate-800'
+                : 'cursor-not-allowed border-slate-200 bg-slate-50 text-slate-400 dark:border-slate-800 dark:bg-slate-950/40 dark:text-slate-600',
             )}
-            aria-pressed={isFormatted}
+            aria-pressed={Boolean(formattedJson) && isFormatted}
+            title={formattedJson ? undefined : 'Body is not valid JSON'}
             onClick={() => {
               if (formattedJson) {
                 setIsFormatted((current) => !current);
               }
             }}
           >
-            {isFormatted ? 'Raw' : 'Formatted'}
+            <span className="material-icons-round text-sm" aria-hidden="true">
+              {isFormatted ? 'receipt_long' : 'code'}
+            </span>
+            {isFormatted ? 'Source' : 'Format'}
           </button>
         </div>
       </div>

--- a/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
+++ b/src/ServiceBusViewer.Web/src/components/viewer/SendMessageForm.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from 'react';
+import { Alert } from '../common/Alert';
 import { serviceBusApi } from '../../api/serviceBusApi';
 import { useStoredBoolean } from '../../hooks/useStoredBoolean';
 import { cx } from '../../lib/cx';
@@ -47,6 +48,8 @@ interface SendMessageFormProps {
 	requiresSession: boolean;
 	entityName: string | null;
 	topicName: string | null;
+	sendResultMessage: string | null;
+	sendErrorMessages: string[];
 	onSubmit: (request: SendMessageRequestDto) => Promise<void>;
 	onValidationError: (messages: string[]) => void;
 }
@@ -58,6 +61,10 @@ const emptyProperties: SendMessagePropertiesDto = {
 	scheduledEnqueueTime: null,
 	sessionId: '',
 	timeToLive: '',
+	to: '',
+	replyTo: '',
+	subject: '',
+	partitionKey: '',
 };
 
 function createProperty(): ApplicationPropertyInputDto {
@@ -77,10 +84,13 @@ export function SendMessageForm({
 	requiresSession,
 	entityName,
 	topicName,
+	sendResultMessage,
+	sendErrorMessages,
 	onSubmit,
 	onValidationError,
 }: SendMessageFormProps) {
 	const [isOpen, setIsOpen] = useStoredBoolean('sendFormOpen', true);
+	const [showAdvanced, setShowAdvanced] = useStoredBoolean('sendFormAdvanced', false);
 	const [messageBody, setMessageBody] = useState('');
 	const [messageProperties, setMessageProperties] =
 		useState<SendMessagePropertiesDto>(emptyProperties);
@@ -99,6 +109,29 @@ export function SendMessageForm({
 	const loadJsonStatusTimerRef = useRef<number | null>(null);
 	const loadJsonFadeTimerRef = useRef<number | null>(null);
 	const [duplicateDetectionArmed, setDuplicateDetectionArmed] = useState(false);
+	const [pasteStatus, setPasteStatus] = useState<'idle' | 'success' | 'invalid'>('idle');
+	const pasteStatusTimerRef = useRef<number | null>(null);
+
+	const clearPasteStatusTimers = () => {
+		if (pasteStatusTimerRef.current !== null) {
+			window.clearTimeout(pasteStatusTimerRef.current);
+			pasteStatusTimerRef.current = null;
+		}
+	};
+
+	const clearPasteStatus = () => {
+		clearPasteStatusTimers();
+		setPasteStatus('idle');
+	};
+
+	const showPasteStatus = (status: 'success' | 'invalid') => {
+		clearPasteStatusTimers();
+		setPasteStatus(status);
+		pasteStatusTimerRef.current = window.setTimeout(() => {
+			pasteStatusTimerRef.current = null;
+			setPasteStatus('idle');
+		}, 3000);
+	};
 
 	const clearLoadJsonStatusTimers = () => {
 		if (loadJsonStatusTimerRef.current !== null) {
@@ -132,7 +165,12 @@ export function SendMessageForm({
 		}, 5000);
 	};
 
-	useEffect(() => clearLoadJsonStatusTimers, []);
+	useEffect(() => {
+		return () => {
+			clearLoadJsonStatusTimers();
+			clearPasteStatusTimers();
+		};
+	}, []);
 
 	const duplicateDetectionWarning = duplicateDetection === true && duplicateDetectionArmed;
 
@@ -246,6 +284,10 @@ export function SendMessageForm({
 			errors.push('The Correlation ID must be 128 characters or fewer.');
 		}
 
+		if (messageProperties.partitionKey.length > 128) {
+			errors.push('The Partition Key must be 128 characters or fewer.');
+		}
+
 		return errors;
 	};
 
@@ -256,6 +298,7 @@ export function SendMessageForm({
 		setIsContentTypeMenuOpen(false);
 		setContentTypeFilter('');
 		clearLoadJsonStatus();
+		clearPasteStatus();
 		// A successful send is the warning reset: do not re-arm here.
 	};
 
@@ -306,24 +349,28 @@ export function SendMessageForm({
 
 	const handleLoadJson = async () => {
 		clearLoadJsonStatus();
+		setPasteStatus('idle');
 		let pastedText: string;
 		try {
 			pastedText = await navigator.clipboard.readText();
 		} catch {
 			showLoadJsonError(
-				'Clipboard access was blocked. Allow clipboard access and try again, or paste the JSON into the payload manually.',
+				'Clipboard access was blocked. Allow clipboard access and try again.',
 			);
+			showPasteStatus('invalid');
 			return;
 		}
 
 		if (pastedText.length === 0) {
 			showLoadJsonError('The clipboard is empty. Copy a full message as JSON first.');
+			showPasteStatus('invalid');
 			return;
 		}
 
 		const result = parseSendWindowJson(pastedText);
 		if (!result.ok) {
 			showLoadJsonError(result.error);
+			showPasteStatus('invalid');
 			return;
 		}
 
@@ -345,6 +392,8 @@ export function SendMessageForm({
 		if (duplicateDetection === true && pastedMessageId !== undefined && pastedMessageId.length > 0) {
 			setDuplicateDetectionArmed(true);
 		}
+
+		showPasteStatus('success');
 	};
 
 	return (
@@ -369,24 +418,67 @@ export function SendMessageForm({
 						type="button"
 						disabled={!isOpen}
 						className={cx(
-							'inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-500 transition hover:border-slate-300 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:text-white',
-							!isOpen && 'cursor-not-allowed opacity-40 hover:border-slate-200 hover:text-slate-500 dark:hover:border-slate-800 dark:hover:text-slate-300',
+							'inline-flex min-w-[10.5rem] items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[11px] font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500',
+							!isOpen
+								? 'cursor-not-allowed border-slate-200 bg-white text-slate-500 opacity-40 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300'
+								: pasteStatus === 'success'
+									? 'border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-900/60 dark:bg-emerald-950/30 dark:text-emerald-400'
+									: pasteStatus === 'invalid'
+										? 'border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-900/60 dark:bg-rose-950/30 dark:text-rose-400'
+										: 'border-slate-200 bg-white text-slate-500 hover:border-slate-300 hover:text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:text-white',
 						)}
 						onClick={() => void handleLoadJson()}
 						title="Paste the full message JSON from the clipboard into this form"
 					>
 						<span className="material-icons-round text-sm">content_paste</span>
-						Paste From Clipboard
+						{pasteStatus === 'success'
+							? 'Successful'
+							: pasteStatus === 'invalid'
+								? 'Not valid JSON'
+								: 'Paste From Clipboard'}
 					</button>
 					<button
 						type="button"
-						className="inline-flex w-20 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
+						role="switch"
+						aria-checked={showAdvanced}
+						aria-label="Toggle advanced fields"
+						title="Show or hide advanced fields"
+						disabled={!isOpen}
+						className={cx(
+							'inline-flex h-7 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 text-[11px] font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:border-slate-800 dark:bg-slate-900',
+							showAdvanced
+								? 'text-slate-700 dark:text-slate-200'
+								: 'text-slate-500 dark:text-slate-300',
+							!isOpen &&
+							'cursor-not-allowed opacity-40 hover:border-slate-200 dark:hover:border-slate-800',
+						)}
+						onClick={() => setShowAdvanced((current) => !current)}
+					>
+						<span
+							aria-hidden="true"
+							className={cx(
+								'relative inline-flex h-4 w-7 items-center rounded-full transition-colors',
+								showAdvanced ? 'bg-brand-600' : 'bg-slate-300 dark:bg-slate-600',
+							)}
+						>
+							<span
+								className={cx(
+									'absolute h-3 w-3 rounded-full bg-white shadow transition-transform',
+									showAdvanced ? 'translate-x-3.5' : 'translate-x-0.5',
+								)}
+							/>
+						</span>
+						Advanced
+					</button>
+					<button
+						type="button"
+						className="inline-flex h-7 w-24 items-center justify-center gap-1 rounded-lg bg-slate-100 px-2 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
 						onClick={() => setIsOpen((current) => !current)}
 					>
 						<span className="material-icons-round text-sm">
 							{isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
 						</span>
-						<span className="text-center">{isOpen ? 'Hide' : 'Show'}</span>
+						<span className="w-14 text-center">{isOpen ? 'Collapse' : 'Expand'}</span>
 					</button>
 				</div>
 			</div>
@@ -394,12 +486,12 @@ export function SendMessageForm({
 			<div className={cx('send-form-transition', !isOpen && 'js-send-form-hidden')}>
 				<form className="p-4 lg:p-6" onSubmit={(event) => void handleSubmit(event)}>
 					<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_19rem]">
-						<div>
+						<div className="flex min-h-0 flex-col">
 							<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 								Payload
 							</label>
 							<textarea
-								className="block min-h-56 w-full rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:placeholder:text-slate-500 dark:focus:border-brand-400"
+								className="block min-h-56 w-full flex-1 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 font-mono text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition placeholder:text-slate-400 focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:placeholder:text-slate-500 dark:focus:border-brand-400"
 								rows={12}
 								value={messageBody}
 								onChange={(event) => setMessageBody(event.target.value)}
@@ -410,12 +502,19 @@ export function SendMessageForm({
 							<div>
 								<label className="mb-2 flex items-center justify-between pr-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
 									Message ID
-									{duplicateDetectionWarning ? (
+									{duplicateDetection === true ? (
 										<span
 											id="messageIdDuplicateDetectionWarning"
-											className="flex items-center gap-1 normal-case tracking-normal text-xs font-medium text-amber-700 dark:text-amber-400"
+											className={cx(
+												'flex items-center gap-1 normal-case tracking-normal text-xs font-medium',
+												duplicateDetectionWarning
+													? 'text-amber-700 dark:text-amber-400'
+													: 'text-slate-500 dark:text-slate-400',
+											)}
 										>
-											<span className="material-icons-round text-sm" aria-hidden="true">warning_amber</span>
+											<span className="material-icons-round text-sm" aria-hidden="true">
+												{duplicateDetectionWarning ? 'warning_amber' : 'info'}
+											</span>
 											<span>Duplicate detection enabled</span>
 										</span>
 									) : null}
@@ -424,17 +523,17 @@ export function SendMessageForm({
 									type="text"
 									maxLength={128}
 									aria-invalid={duplicateDetectionWarning || undefined}
-									aria-describedby={duplicateDetectionWarning ? 'messageIdDuplicateDetectionWarning' : undefined}
+									aria-describedby={duplicateDetection === true ? 'messageIdDuplicateDetectionWarning' : undefined}
 									className={cx(
 										messageIdFieldClasses,
 										duplicateDetectionWarning
 											? messageIdFieldWarningClasses
 											: messageIdFieldNormalClasses,
 									)}
-								value={messageProperties.messageId}
-								onChange={(event) => handlePropertiesChange('messageId', event)}
-							/>
-						</div>
+									value={messageProperties.messageId}
+									onChange={(event) => handlePropertiesChange('messageId', event)}
+								/>
+							</div>
 
 							<div>
 								<label className="mb-2 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -453,6 +552,22 @@ export function SendMessageForm({
 									onChange={(event) => handlePropertiesChange('sessionId', event)}
 								/>
 							</div>
+
+							{showAdvanced ? (
+								<div>
+									<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+										Partition Key
+									</label>
+									<input
+										type="text"
+										maxLength={128}
+										placeholder="Optional"
+										className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+										value={messageProperties.partitionKey}
+										onChange={(event) => handlePropertiesChange('partitionKey', event)}
+									/>
+								</div>
+							) : null}
 
 							<div>
 								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -574,11 +689,54 @@ export function SendMessageForm({
 						</div>
 					</div>
 
+					{showAdvanced ? (
+						<div className="mt-6 grid gap-4 sm:grid-cols-3">
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									To
+								</label>
+								<input
+									type="text"
+									placeholder="Optional"
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.to}
+									onChange={(event) => handlePropertiesChange('to', event)}
+								/>
+							</div>
+
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Reply To
+								</label>
+								<input
+									type="text"
+									placeholder="Optional"
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.replyTo}
+									onChange={(event) => handlePropertiesChange('replyTo', event)}
+								/>
+							</div>
+
+							<div>
+								<label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
+									Subject
+								</label>
+								<input
+									type="text"
+									placeholder="Optional"
+									className="block w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm shadow-slate-200/40 transition focus:border-brand-500 focus:ring-2 focus:ring-brand-500/20 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100 dark:shadow-black/20 dark:focus:border-brand-400"
+									value={messageProperties.subject}
+									onChange={(event) => handlePropertiesChange('subject', event)}
+								/>
+							</div>
+						</div>
+					) : null}
+
 					<div className="mt-6">
 						<div className="mb-3 flex flex-wrap items-center justify-between gap-3">
 							<div>
 								<label className="block text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-									Application Properties
+									Custom Properties
 								</label>
 								<p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
 									Optional typed key-value metadata to attach to the outgoing message.
@@ -652,7 +810,20 @@ export function SendMessageForm({
 						</div>
 					</div>
 
-					<div className="mt-6 flex justify-end">
+					<div className="mt-6 flex flex-wrap items-center justify-end gap-3">
+						{sendErrorMessages.length > 0 ? (
+							<Alert
+								className="min-w-0 flex-1 basis-full lg:basis-auto"
+								messages={sendErrorMessages}
+								tone="error"
+							/>
+						) : (
+							<Alert
+								className="min-w-0 flex-1 basis-full lg:basis-auto"
+								messages={sendResultMessage ? [sendResultMessage] : []}
+								tone="success"
+							/>
+						)}
 						<button
 							type="submit"
 							className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-950/20 transition hover:bg-brand-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"

--- a/src/ServiceBusViewer.Web/src/hooks/useStoredBoolean.ts
+++ b/src/ServiceBusViewer.Web/src/hooks/useStoredBoolean.ts
@@ -1,26 +1,41 @@
-import { useEffect, useState } from 'react';
+import {
+	useEffect,
+	useRef,
+	useState,
+	type Dispatch,
+	type SetStateAction,
+} from 'react';
 
 function readStoredBoolean(key: string, defaultValue: boolean): boolean {
-  try {
-    const storedValue = window.localStorage.getItem(key);
-    return storedValue === null ? defaultValue : storedValue === 'true';
-  } catch {
-    return defaultValue;
-  }
+	try {
+		const storedValue = window.localStorage.getItem(key);
+		return storedValue === null ? defaultValue : storedValue === 'true';
+	} catch {
+		return defaultValue;
+	}
 }
 
 export function useStoredBoolean(key: string, defaultValue: boolean) {
-  const [value, setValue] = useState<boolean>(() =>
-    readStoredBoolean(key, defaultValue),
-  );
+	const [value, setValue] = useState<boolean>(() =>
+		readStoredBoolean(key, defaultValue),
+	);
+	const hasChangedRef = useRef(false);
 
-  useEffect(() => {
-    try {
-      window.localStorage.setItem(key, value ? 'true' : 'false');
-    } catch {
-      // Ignore storage write failures.
-    }
-  }, [key, value]);
+	useEffect(() => {
+		if (!hasChangedRef.current) {
+			return;
+		}
+		try {
+			window.localStorage.setItem(key, value ? 'true' : 'false');
+		} catch {
+			// Ignore storage write failures.
+		}
+	}, [key, value]);
 
-  return [value, setValue] as const;
+	const setAndPersist: Dispatch<SetStateAction<boolean>> = (nextValue) => {
+		hasChangedRef.current = true;
+		setValue(nextValue);
+	};
+
+	return [value, setAndPersist] as const;
 }

--- a/src/ServiceBusViewer.Web/src/index.css
+++ b/src/ServiceBusViewer.Web/src/index.css
@@ -241,14 +241,6 @@
     @apply text-slate-500 dark:text-slate-400;
   }
 
-  .js-json-toggle {
-    display: none;
-  }
-
-  .js-json-toggle.js-json-toggle-visible {
-    display: inline-flex;
-  }
-
   .send-form-transition {
     max-height: 220rem;
     opacity: 1;

--- a/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
+++ b/src/ServiceBusViewer.Web/src/lib/sendWindowJsonImport.ts
@@ -35,6 +35,10 @@ const supportedPropertyKeys = [
 	'contentType',
 	'scheduledEnqueueTime',
 	'timeToLive',
+	'to',
+	'replyTo',
+	'subject',
+	'partitionKey',
 ] as const satisfies readonly (keyof SendMessagePropertiesDto)[];
 
 export type SendWindowJsonImport = {
@@ -122,6 +126,10 @@ function parseApplicationProperties(
 
 	const rows: ApplicationPropertyInputDto[] = [];
 	for (const [key, entry] of Object.entries(raw)) {
+		if (key === 'Diagnostic-Id') {
+			continue;
+		}
+
 		if (!isRecord(entry) || !('value' in entry)) {
 			throw new Error(`Application property '${key}' must be an object with a value.`);
 		}
@@ -146,7 +154,7 @@ export function parseSendWindowJson(text: string): SendWindowJsonImportResult {
 	try {
 		parsed = JSON.parse(text);
 	} catch {
-		return { ok: false, error: 'The clipboard text is not valid JSON.' };
+		return { ok: false, error: '' };
 	}
 
 	if (!isRecord(parsed)) {

--- a/src/ServiceBusViewer.Web/src/pages/ConnectPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ConnectPage.tsx
@@ -209,8 +209,6 @@ export function ConnectPage() {
 								</div>
 							</div>
 
-							<Alert className="mt-5" messages={errorMessages} tone="error" />
-
 							<form className="mt-6 space-y-5" onSubmit={(event) => void handleSubmit(event)}>
 								<div>
 									<label className="mb-2 block text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
@@ -271,21 +269,33 @@ export function ConnectPage() {
 								</div>
 
 								{sessionState.isRunningInContainer && (
-									<div className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-xs leading-5 text-slate-500 dark:border-slate-800 dark:bg-slate-950/60 dark:text-slate-400">
+									<div className="flex items-start gap-2 rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-xs leading-5 text-slate-500 dark:border-slate-800 dark:bg-slate-950/60 dark:text-slate-400">
 										<span className="material-icons-round text-base" aria-hidden="true">
 											info
 										</span>
-										<span>
-											For Docker or Podman, use{' '}
-											<span className="font-mono text-slate-700 dark:text-slate-200">
-												host.docker.internal
-											</span>{' '}
-											instead of{' '}
-											<span className="font-mono text-slate-700 dark:text-slate-200">
-												localhost
-											</span>{' '}
-											when targeting the emulator on the host machine.
-										</span>
+										<div>
+											<p>To reach the emulator on the host machine:</p>
+											<ul className="mt-1 list-disc space-y-1 pl-4">
+												<li>
+													Docker: use{' '}
+													<span className="font-mono text-slate-700 dark:text-slate-200">
+														host.docker.internal
+													</span>
+												</li>
+												<li>
+													Podman: use{' '}
+													<span className="font-mono text-slate-700 dark:text-slate-200">
+														host.docker.internal
+													</span>{' '}
+													or{' '}
+													<span className="font-mono text-slate-700 dark:text-slate-200">
+														host.containers.internal
+													</span>
+													, and the host service must listen on a non-loopback
+													interface (not just 127.0.0.1) to be reachable
+												</li>
+											</ul>
+										</div>
 									</div>
 								)}
 
@@ -306,6 +316,8 @@ export function ConnectPage() {
 									</svg>
 									{isSubmitting ? 'Connecting...' : 'Connect'}
 								</button>
+
+								<Alert className="mt-5" messages={errorMessages} tone="error" />
 							</form>
 						</section>
 					</div>

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 import { serviceBusApi } from '../api/serviceBusApi';
 import { Alert } from '../components/common/Alert';
+import { CopyFullMessageButton } from '../components/common/CopyFullMessageButton';
 import { JsonMessageBody } from '../components/common/JsonMessageBody';
 import { EntitySidebar } from '../components/entities/EntitySidebar';
 import { AppLayout } from '../components/layout/AppLayout';
@@ -28,14 +29,11 @@ import type {
 type ViewerAction = 'disconnect' | 'receive' | 'refresh' | 'send';
 
 function buildSendResultMessage(request: SendMessageRequestDto) {
-	const { contentType, messageId } = request.sendMessageProperties;
-	const contentTypeDescription = contentType.trim()
-		? `with content type '${contentType}'`
-		: 'without a content type';
+	const { messageId } = request.sendMessageProperties;
 
 	return messageId.trim()
-		? `Message '${messageId}' sent successfully ${contentTypeDescription}.`
-		: `Message sent successfully ${contentTypeDescription}.`;
+		? `Message '${messageId}' sent successfully.`
+		: 'Message sent successfully.';
 }
 
 export function ViewerPage() {
@@ -45,6 +43,7 @@ export function ViewerPage() {
 	const currentViewer = viewer;
 	const [pendingAction, setPendingAction] = useState<ViewerAction | null>(null);
 	const [errorMessages, setErrorMessages] = useState<string[]>([]);
+	const [sendErrorMessages, setSendErrorMessages] = useState<string[]>([]);
 	const [selectionKey, setSelectionKey] = useState<string | null>(null);
 	const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
 	const [receiveSessionId, setReceiveSessionId] = useState(viewer?.receiveSessionId ?? '');
@@ -77,6 +76,29 @@ export function ViewerPage() {
 		setReceiveSessionId(viewer?.receiveSessionId ?? '');
 	}, [viewer?.receiveSessionId]);
 
+	const sendResultMessage = viewer?.sendResultMessage ?? null;
+
+	useEffect(() => {
+		if (!sendResultMessage || sendErrorMessages.length > 0) {
+			return;
+		}
+
+		const timerId = window.setTimeout(() => {
+			setViewerState((currentViewer) => {
+				if (!currentViewer) {
+					return currentViewer;
+				}
+
+				return {
+					...currentViewer,
+					sendResultMessage: null,
+				};
+			});
+		}, 5000);
+
+		return () => window.clearTimeout(timerId);
+	}, [sendResultMessage, sendErrorMessages.length, setViewerState]);
+
 	const syncViewer = useCallback(
 		async (nextViewer: ViewerState) => {
 			setViewerState(nextViewer);
@@ -89,12 +111,18 @@ export function ViewerPage() {
 		async (action: ViewerAction, work: () => Promise<void>) => {
 			setPendingAction(action);
 			setErrorMessages([]);
+			setSendErrorMessages([]);
 
 			try {
 				await work();
 				return true;
 			} catch (error: unknown) {
-				setErrorMessages(getErrorMessages(error));
+				const messages = getErrorMessages(error);
+				if (action === 'send') {
+					setSendErrorMessages(messages);
+				} else {
+					setErrorMessages(messages);
+				}
 				return false;
 			} finally {
 				setPendingAction(null);
@@ -110,11 +138,13 @@ export function ViewerPage() {
 
 		const properties = currentViewer.displayedMessage.properties;
 		return [
-			['Message ID', properties.messageId],
 			['Content Type', formatNullable(properties.contentType, 'not set')],
-			['Partition Key', formatNullable(properties.partitionKey)],
-			['Scheduled Enqueue', formatDateTime(properties.scheduledEnqueueTime)],
 			['Time To Live', formatNullable(properties.timeToLive)],
+			['Scheduled Enqueue', formatDateTime(properties.scheduledEnqueueTime)],
+			['Correlation ID', formatNullable(properties.correlationId)],
+			['Subject', formatNullable(properties.subject)],
+			['To', formatNullable(properties.to)],
+			['Reply To', formatNullable(properties.replyTo)]
 		];
 	}, [currentViewer?.displayedMessage]);
 
@@ -135,6 +165,13 @@ export function ViewerPage() {
 	const peekedMessageSummary = currentViewer
 		? buildPeekedMessageSummary(currentViewer.messages, currentViewer.hasMoreMessages)
 		: '0 total';
+	const showScheduledEnqueue = currentViewer?.messages.some((message) =>
+		Boolean(message.properties.scheduledEnqueueTime),
+	) ?? false;
+	const showPartitionKey = currentViewer?.messages.some((message) =>
+		Boolean(message.properties.partitionKey),
+	) ?? false;
+	const peekedMessageColumnCount = 5 + (showScheduledEnqueue ? 1 : 0) + (showPartitionKey ? 1 : 0);
 
 	const handleDisconnect = async () => {
 		await runAction('disconnect', async () => {
@@ -148,6 +185,7 @@ export function ViewerPage() {
 		const nextSelectionKey = getEntityKey(entity);
 		setSelectionKey(nextSelectionKey);
 		setErrorMessages([]);
+		setSendErrorMessages([]);
 
 		try {
 			const nextViewer = await syncViewer(await serviceBusApi.selectEntity(entity));
@@ -182,22 +220,27 @@ export function ViewerPage() {
 	};
 
 	const handleSend = async (request: SendMessageRequestDto) => {
+		if (currentViewer) {
+			setViewerState({
+				...currentViewer,
+				sendResultMessage: null,
+			});
+		}
+
 		const succeeded = await runAction('send', async () => {
 			await serviceBusApi.send(request);
-
-			if (currentViewer) {
-				setViewerState({
-					...currentViewer,
-					sendResultMessage: buildSendResultMessage(request),
-				});
-			}
+			const sendResultMessage = buildSendResultMessage(request);
 
 			try {
 				const nextViewer = await syncViewer(await serviceBusApi.refreshViewer());
 				setReceiveSessionId(nextViewer.receiveSessionId ?? '');
 				setExpandedRows(new Set());
+				setViewerState({
+					...nextViewer,
+					sendResultMessage,
+				});
 			} catch {
-				setErrorMessages([
+				setSendErrorMessages([
 					'The message was sent successfully, but the message list could not be refreshed. Use Refresh to try again.',
 				]);
 			}
@@ -217,7 +260,7 @@ export function ViewerPage() {
 					<table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
 						<thead className="bg-slate-50 text-slate-500 dark:bg-slate-950/40 dark:text-slate-400">
 							<tr>
-								<th className="px-4 py-2 text-left font-medium">Application Property</th>
+								<th className="px-4 py-2 text-left font-medium">Custom Property</th>
 								<th className="px-4 py-2 text-left font-medium">Value</th>
 								<th className="px-4 py-2 text-left font-medium">Type</th>
 							</tr>
@@ -242,7 +285,7 @@ export function ViewerPage() {
 			);
 		}
 
-		return <div className={emptyClassName}>No application properties on this message.</div>;
+		return <div className={emptyClassName}>No custom properties on this message.</div>;
 	};
 
 	const toggleExpandedRow = (rowKey: string) => {
@@ -351,32 +394,28 @@ export function ViewerPage() {
 
 						<div className="custom-scrollbar flex-1 overflow-y-auto p-4 lg:p-6">
 							<Alert className="mb-6" messages={errorMessages} tone="error" />
-							<Alert
-								className="mb-6"
-								messages={currentViewer?.sendResultMessage ? [currentViewer.sendResultMessage] : []}
-								tone="success"
-							/>
 
-						<SendMessageForm
-							canSend={Boolean(currentViewer?.entityName)}
-							entityName={currentViewer?.entityName ?? null}
-							isSubmitting={pendingAction === 'send'}
-							requiresSession={Boolean(currentViewer?.requiresSession)}
-							topicName={currentViewer?.topicName ?? null}
-							onSubmit={handleSend}
-							onValidationError={setErrorMessages}
-						/>
+							<SendMessageForm
+								canSend={Boolean(currentViewer?.entityName)}
+								entityName={currentViewer?.entityName ?? null}
+								isSubmitting={pendingAction === 'send'}
+								requiresSession={Boolean(currentViewer?.requiresSession)}
+								sendResultMessage={currentViewer?.sendResultMessage ?? null}
+								sendErrorMessages={sendErrorMessages}
+								topicName={currentViewer?.topicName ?? null}
+								onSubmit={handleSend}
+								onValidationError={setSendErrorMessages}
+							/>
 
 							<section className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm shadow-slate-200/40 dark:border-slate-800 dark:bg-slate-900 dark:shadow-black/20">
 								<div className="flex items-center justify-between border-b border-slate-200 bg-slate-50/80 px-4 py-3 dark:border-slate-800 dark:bg-slate-950/40">
 									<h2 className="text-xs font-bold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
 										Last Received Message
 									</h2>
-									{currentViewer?.displayedMessage ? (
-										<span className="rounded-xl bg-slate-200 px-2 py-1 font-mono text-[11px] text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-											ID: {currentViewer.displayedMessage.properties.messageId}
-										</span>
-									) : null}
+									<CopyFullMessageButton
+										message={currentViewer?.displayedMessage ?? null}
+										disabled={!currentViewer?.displayedMessage}
+									/>
 								</div>
 
 								<div className="p-4 lg:p-6">
@@ -393,29 +432,26 @@ export function ViewerPage() {
 												</div>
 												<div>
 													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
+														Message ID
+													</div>
+													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
+														{currentViewer.displayedMessage.properties.messageId}
+													</div>
+												</div>
+												<div>
+													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
+														Partition Key
+													</div>
+													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
+														{formatNullable(currentViewer.displayedMessage.properties.partitionKey)}
+													</div>
+												</div>
+												<div>
+													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
 														Session ID
 													</div>
 													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
 														{formatNullable(currentViewer.displayedMessage.properties.sessionId)}
-													</div>
-												</div>
-												<div>
-													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
-														Correlation ID
-													</div>
-													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
-														{formatNullable(currentViewer.displayedMessage.properties.correlationId)}
-													</div>
-												</div>
-												<div>
-													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
-														Content Type
-													</div>
-													<div className="mt-1 text-xs text-slate-700 dark:text-slate-200">
-														{formatNullable(
-															currentViewer.displayedMessage.properties.contentType,
-															'not set',
-														)}
 													</div>
 												</div>
 											</div>
@@ -423,13 +459,19 @@ export function ViewerPage() {
 											<div className="mt-4 grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
 												<div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
 													<table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+														<thead className="bg-slate-50 text-slate-500 dark:bg-slate-950/40 dark:text-slate-400">
+															<tr>
+																<th className="px-4 py-2 text-left font-medium">Message Property</th>
+																<th className="px-4 py-2 text-left font-medium">Value</th>
+															</tr>
+														</thead>
 														<tbody className="divide-y divide-slate-100 dark:divide-slate-800">
 															{activeMessagePropertyRows.map(([label, value]) => (
 																<tr key={label}>
-																	<th className="w-40 bg-slate-50 px-4 py-3 text-left font-medium text-slate-500 dark:bg-slate-950/40 dark:text-slate-400">
+																	<th className="w-44 whitespace-nowrap bg-white px-4 py-2 text-xs font-medium text-slate-700 dark:bg-slate-900 dark:text-slate-200">
 																		{label}
 																	</th>
-																	<td className="px-4 py-3 text-slate-700 dark:text-slate-200">
+																	<td className="px-4 py-2 text-xs text-slate-600 dark:text-slate-300">
 																		{value}
 																	</td>
 																</tr>
@@ -448,7 +490,6 @@ export function ViewerPage() {
 
 											<JsonMessageBody
 												body={currentViewer.displayedMessage.body}
-												fullMessage={currentViewer.displayedMessage}
 												className="mt-6"
 											/>
 										</>
@@ -482,10 +523,12 @@ export function ViewerPage() {
 											<thead className="border-b border-slate-200 bg-slate-50 text-slate-500 dark:border-slate-800 dark:bg-slate-950/40 dark:text-slate-400">
 												<tr>
 													<th className="px-4 py-3 font-medium">Message ID</th>
-													<th className="px-4 py-3 font-medium">Enqueued Time</th>
+													{showPartitionKey && <th className="px-4 py-3 font-medium">Partition Key</th>}
+													<th className="px-4 py-3 font-medium">Session</th>
+													<th className="px-4 py-3 font-medium">Enqueued Time / TTL</th>
+													{showScheduledEnqueue && <th className="px-4 py-3 font-medium">Scheduled Enqueue</th>}
 													<th className="px-4 py-3 font-medium">Content Type</th>
-													<th className="px-4 py-3 font-medium">Session / TTL</th>
-													<th className="px-4 py-3 text-right font-medium">Actions</th>
+													<th className="px-4 py-3 text-center font-medium">Actions</th>
 												</tr>
 											</thead>
 											<tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -493,13 +536,11 @@ export function ViewerPage() {
 													const rowKey = createMessageRowKey(message, index);
 													const isExpanded = expandedRows.has(rowKey);
 													const propertyRows: Array<[string, string]> = [
-														['Message ID', message.properties.messageId],
-														['Enqueued Time', formatDateTime(message.properties.enqueuedTimeUtc)],
-														['Content Type', formatNullable(message.properties.contentType, 'not set')],
-														['Partition Key', formatNullable(message.properties.partitionKey)],
-														['Correlation ID', formatNullable(message.properties.correlationId)],
 														['Scheduled Enqueue', formatDateTime(message.properties.scheduledEnqueueTime)],
-														['Time To Live', formatNullable(message.properties.timeToLive)],
+														['Correlation ID', formatNullable(message.properties.correlationId)],
+														['Subject', formatNullable(message.properties.subject)],
+														['To', formatNullable(message.properties.to)],
+														['Reply To', formatNullable(message.properties.replyTo)],
 													];
 
 													return (
@@ -509,47 +550,66 @@ export function ViewerPage() {
 																	<div className="font-mono text-xs text-slate-700 dark:text-slate-200">
 																		{message.properties.messageId}
 																	</div>
-																	{currentViewer.requiresSession && message.properties.sessionId ? (
-																		<div className="mt-1 text-[11px] text-slate-500 dark:text-slate-400">
-																			Session: {message.properties.sessionId}
-																		</div>
-																	) : null}
+																</td>
+																{showPartitionKey && (
+																	<td className="px-4 py-3 font-mono text-xs text-slate-700 dark:text-slate-200">
+																		{formatNullable(message.properties.partitionKey)}
+																	</td>
+																)}
+																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+																	{formatNullable(message.properties.sessionId, 'No session')}
 																</td>
 																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
 																	{formatDateTimeShort(message.properties.enqueuedTimeUtc)}
-																</td>
-																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
-																	{formatNullable(message.properties.contentType, 'not set')}
-																</td>
-																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
-																	{formatNullable(message.properties.sessionId, 'No session')}
 																	<div className="mt-1 text-[11px] text-slate-400 dark:text-slate-500">
 																		TTL: {formatNullable(message.properties.timeToLive)}
 																	</div>
 																</td>
-																<td className="px-4 py-3 text-right">
-																	<button
-																		type="button"
-																		className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-brand-700 transition hover:border-brand-200 hover:bg-brand-50 dark:border-slate-800 dark:bg-slate-900 dark:text-brand-300 dark:hover:border-brand-900/60 dark:hover:bg-brand-950/30"
-																		onClick={() => toggleExpandedRow(rowKey)}
-																	>
-																		<span>{isExpanded ? 'Collapse' : 'Expand'}</span>
-																	</button>
+																{showScheduledEnqueue && (
+																	<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+																		{message.properties.scheduledEnqueueTime
+																			? formatDateTimeShort(message.properties.scheduledEnqueueTime)
+																			: 'n/a'}
+																	</td>
+																)}
+																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+																	{formatNullable(message.properties.contentType, 'not set')}
+																</td>
+																<td className="px-4 py-3">
+																	<div className="flex items-center justify-end gap-2">
+																		<CopyFullMessageButton message={message} />
+																		<button
+																			type="button"
+																			className="inline-flex h-7 items-center gap-1 rounded-lg bg-slate-100 px-2 text-[11px] font-medium text-slate-500 transition hover:bg-slate-200 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-white"
+																			onClick={() => toggleExpandedRow(rowKey)}
+																		>
+																			<span className="material-icons-round text-sm">
+																				{isExpanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'}
+																			</span>
+																			<span className="w-14 text-center">{isExpanded ? 'Collapse' : 'Expand'}</span>
+																		</button>
+																	</div>
 																</td>
 															</tr>
 															{isExpanded ? (
 																<tr className="bg-slate-50/70 dark:bg-slate-950/50">
-																	<td colSpan={5} className="max-w-0 px-4 py-4">
+																	<td colSpan={peekedMessageColumnCount} className="max-w-0 px-4 py-4">
 																		<div className="grid gap-6 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
 																			<div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
 																				<table className="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+																					<thead className="bg-slate-50 text-slate-500 dark:bg-slate-950/40 dark:text-slate-400">
+																						<tr>
+																							<th className="px-4 py-2 text-left font-medium">Message Property</th>
+																							<th className="px-4 py-2 text-left font-medium">Value</th>
+																						</tr>
+																					</thead>
 																					<tbody className="divide-y divide-slate-100 dark:divide-slate-800">
 																						{propertyRows.map(([label, value]) => (
 																							<tr key={`${rowKey}-${label}`}>
-																								<th className="w-40 bg-white px-4 py-3 text-left font-medium text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+																								<th className="w-44 whitespace-nowrap bg-white px-4 py-2 text-xs font-medium text-slate-700 dark:bg-slate-900 dark:text-slate-200">
 																									{label}
 																								</th>
-																								<td className="px-4 py-3 text-slate-700 dark:text-slate-200">
+																								<td className="px-4 py-2 text-xs text-slate-600 dark:text-slate-300">
 																									{value}
 																								</td>
 																							</tr>
@@ -566,11 +626,7 @@ export function ViewerPage() {
 																			</div>
 																		</div>
 
-																		<JsonMessageBody
-																			body={message.body}
-																			fullMessage={message}
-																			className="mt-4"
-																		/>
+																		<JsonMessageBody body={message.body} className="mt-4" />
 																	</td>
 																</tr>
 															) : null}

--- a/src/ServiceBusViewer.Web/src/state/AppStateContext.tsx
+++ b/src/ServiceBusViewer.Web/src/state/AppStateContext.tsx
@@ -21,8 +21,10 @@ interface AppStateContextValue {
   refreshSessionState: () => Promise<SessionStateDto>;
   setAppliedEntityFilterText: (filterText: string) => void;
   setEntityFilterText: (filterText: string) => void;
-  setViewerState: (viewer: ViewerState | null) => void;
+  setViewerState: (viewer: SetViewerStateValue) => void;
 }
+
+type SetViewerStateValue = ViewerState | null | ((current: ViewerState | null) => ViewerState | null);
 
 const AppStateContext = createContext<AppStateContextValue | null>(null);
 
@@ -66,19 +68,26 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
     });
   }, [refreshSessionState]);
 
-  const setViewerState = useCallback((viewer: ViewerState | null) => {
-    setSessionState((current) => {
-      if (!current) {
-        return current;
-      }
+  const setViewerState = useCallback(
+    (
+      viewer: SetViewerStateValue,
+    ) => {
+      setSessionState((current) => {
+        if (!current) {
+          return current;
+        }
 
-      return {
-        ...current,
-        isConnected: viewer !== null,
-        viewer,
-      };
-    });
-  }, []);
+        const nextViewer = typeof viewer === 'function' ? viewer(current.viewer) : viewer;
+
+        return {
+          ...current,
+          isConnected: nextViewer !== null,
+          viewer: nextViewer,
+        };
+      });
+    },
+    [],
+  );
 
   const value = useMemo<AppStateContextValue>(
     () => ({

--- a/src/ServiceBusViewer.Web/src/types/serviceBus.ts
+++ b/src/ServiceBusViewer.Web/src/types/serviceBus.ts
@@ -22,6 +22,9 @@ export interface ReceivedMessagePropertiesDto {
 	enqueuedTimeUtc: string;
 	scheduledEnqueueTime: string | null;
 	timeToLive: string | null;
+	to: string | null;
+	replyTo: string | null;
+	subject: string | null;
 }
 
 export interface ReceivedMessageApplicationPropertyDto {
@@ -104,6 +107,10 @@ export interface SendMessagePropertiesDto {
 	contentType: string;
 	scheduledEnqueueTime: string | null;
 	timeToLive: string;
+	to: string;
+	replyTo: string;
+	subject: string;
+	partitionKey: string;
 }
 
 export interface SendMessageRequestDto {

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequest.cs
@@ -2,7 +2,6 @@ namespace ServiceBusViewer.Api.Endpoints.Viewer.Send;
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 
 /// <summary>
 /// Request to send a message; includes body, system properties and application properties.
@@ -34,22 +33,28 @@ internal static class SendRequestValidator
 	}
 }
 
-/// <summary>
-/// Optional system properties for the message to send.
-/// </summary>
+/// <summary>Optional system properties for the message to send.</summary>
 /// <param name="MessageId">Message id.</param>
 /// <param name="SessionId">Session id.</param>
 /// <param name="CorrelationId">Correlation id.</param>
 /// <param name="ContentType">Content type.</param>
-/// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601) or null.</param>
+/// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601).</param>
 /// <param name="TimeToLive">Time-to-live string or null.</param>
+/// <param name="To">To property or null.</param>
+/// <param name="ReplyTo">Reply To property or null.</param>
+/// <param name="Subject">Subject or null.</param>
+/// <param name="PartitionKey">Partition key or null.</param>
 public sealed record SendMessagePropertiesRequest(
 	string? MessageId,
 	string? SessionId,
 	string? CorrelationId,
 	string? ContentType,
 	string? ScheduledEnqueueTime,
-	string? TimeToLive);
+	string? TimeToLive,
+	string? To,
+	string? ReplyTo,
+	string? Subject,
+	string? PartitionKey);
 
 /// <summary>Validates a <see cref="SendMessagePropertiesRequest"/> instance.</summary>
 internal static class SendMessagePropertiesRequestValidator
@@ -77,11 +82,8 @@ internal static class SendMessagePropertiesRequestValidator
 		if (!string.IsNullOrWhiteSpace(request.CorrelationId) && request.CorrelationId!.Length > _maxSystemPropertyLength)
 			local[nameof(SendMessagePropertiesRequest.CorrelationId)] = [$"The Correlation ID must be {_maxSystemPropertyLength} characters or fewer."];
 
-		if (!string.IsNullOrWhiteSpace(request.ScheduledEnqueueTime) && !DateTimeOffset.TryParse(request.ScheduledEnqueueTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out _))
-			local[nameof(SendMessagePropertiesRequest.ScheduledEnqueueTime)] = ["Scheduled enqueue time must be a valid date/time value."];
-
-		if (!string.IsNullOrWhiteSpace(request.TimeToLive) && !TimeSpan.TryParse(request.TimeToLive, CultureInfo.InvariantCulture, out _))
-			local[nameof(SendMessagePropertiesRequest.TimeToLive)] = ["Time to live must be a valid time span value."];
+		if (!string.IsNullOrWhiteSpace(request.PartitionKey) && request.PartitionKey.Length > _maxSystemPropertyLength)
+			local[nameof(SendMessagePropertiesRequest.PartitionKey)] = [$"The Partition Key must be {_maxSystemPropertyLength} characters or fewer."];
 
 		errors = local.Count > 0 ? local : null;
 
@@ -89,9 +91,7 @@ internal static class SendMessagePropertiesRequestValidator
 	}
 }
 
-/// <summary>
-/// Single application property entry for a message to send.
-/// </summary>
+/// <summary>Single application property entry for a message to send.</summary>
 /// <param name="Key">Property key.</param>
 /// <param name="Value">Property value.</param>
 /// <param name="Type">Property type name.</param>

--- a/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
+++ b/src/ServiceBusViewer/Api/Endpoints/Viewer/Send/SendRequestHandler.cs
@@ -24,6 +24,7 @@ internal static class SendRequestHandler
 		}
 
 		MessageProperties messageProperties = CreateMessageProperties(request.SendMessageProperties, errors);
+
 		List<ApplicationProperty> applicationProperties = CreateApplicationProperties(request.SendMessageApplicationProperties, errors);
 		if (errors.Count > 0)
 			return Results.ValidationProblem(errors, statusCode: StatusCodes.Status400BadRequest, title: "Validation failed");
@@ -36,23 +37,35 @@ internal static class SendRequestHandler
 		return TypedResults.NoContent();
 	}
 
-	private static MessageProperties CreateMessageProperties(SendMessagePropertiesRequest? request, IDictionary<string, string[]> errors)
+	private static MessageProperties CreateMessageProperties(SendMessagePropertiesRequest? request, Dictionary<string, string[]> errors)
 	{
 		DateTimeOffset? scheduled = null;
-		if (request?.ScheduledEnqueueTime is not null && DateTimeOffset.TryParse(request?.ScheduledEnqueueTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset dto))
-			scheduled = dto;
+		if (!string.IsNullOrEmpty(request?.ScheduledEnqueueTime)) {
+			if (DateTimeOffset.TryParse(request.ScheduledEnqueueTime, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset dto))
+				scheduled = dto;
+			else
+				errors[nameof(SendMessagePropertiesRequest.ScheduledEnqueueTime)] = ["Scheduled enqueue time must be a valid date/time value."];
+		}
 
 		TimeSpan? ttl = null;
-		if (request?.TimeToLive is not null && TimeSpan.TryParse(request?.TimeToLive, CultureInfo.InvariantCulture, out TimeSpan ts))
-			ttl = ts;
+		if (!string.IsNullOrEmpty(request?.TimeToLive)) {
+			if (TimeSpan.TryParse(request.TimeToLive, CultureInfo.InvariantCulture, out TimeSpan ts))
+				ttl = ts;
+			else
+				errors[nameof(SendMessagePropertiesRequest.TimeToLive)] = ["Time to live must be a valid time span value."];
+		}
 
 		return new MessageProperties {
 			MessageId = request?.MessageId,
 			SessionId = request?.SessionId,
+			PartitionKey = request?.PartitionKey,
 			CorrelationId = request?.CorrelationId,
 			ContentType = request?.ContentType,
 			ScheduledEnqueueTime = scheduled,
-			TimeToLive = ttl
+			TimeToLive = ttl,
+			To = request?.To,
+			ReplyTo = request?.ReplyTo,
+			Subject = request?.Subject
 		};
 	}
 

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
@@ -29,7 +29,10 @@ public static class ReceivedMessageExtensions
 					message.Properties.ContentType,
 					message.Properties.EnqueuedTimeUtc.ToString("O", CultureInfo.InvariantCulture),
 					message.Properties.ScheduledEnqueueTime?.ToString("O", CultureInfo.InvariantCulture),
-					message.Properties.TimeToLive?.ToString("c", CultureInfo.InvariantCulture)),
+					message.Properties.TimeToLive?.ToString("c", CultureInfo.InvariantCulture),
+					message.Properties.To,
+					message.Properties.ReplyTo,
+					message.Properties.Subject),
 				message.ApplicationProperties.ToDictionary<KeyValuePair<string, object>, string, ReceivedMessageApplicationProperty>(
 					pair => pair.Key,
 					pair => new ReceivedMessageApplicationProperty(

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
@@ -1,8 +1,6 @@
 namespace ServiceBusViewer.Api.Models;
 
-/// <summary>
-/// System properties for a received message.
-/// </summary>
+/// <summary>System properties for a received message.</summary>
 /// <param name="MessageId">Message id.</param>
 /// <param name="PartitionKey">Partition key if present.</param>
 /// <param name="SessionId">Session id if present.</param>
@@ -11,6 +9,9 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="EnqueuedTimeUtc">Enqueued time in UTC (ISO-8601).</param>
 /// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601) or null.</param>
 /// <param name="TimeToLive">Time-to-live as string or null.</param>
+/// <param name="To">To property or null.</param>
+/// <param name="ReplyTo">Reply To property or null.</param>
+/// <param name="Subject">Subject or null.</param>
 public sealed record ReceivedMessageProperties(
 	string MessageId,
 	string? PartitionKey,
@@ -19,4 +20,7 @@ public sealed record ReceivedMessageProperties(
 	string? ContentType,
 	string EnqueuedTimeUtc,
 	string? ScheduledEnqueueTime,
-	string? TimeToLive);
+	string? TimeToLive,
+	string? To,
+	string? ReplyTo,
+	string? Subject);

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/MessageProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/MessageProperties.cs
@@ -9,6 +9,9 @@ public sealed record MessageProperties
 	/// <summary>Gets the Service Bus session identifier for the outgoing message.</summary>
 	public string? SessionId { get; init; }
 
+	/// <summary>Gets the partition key for the outgoing message.</summary>
+	public string? PartitionKey { get; init; }
+
 	/// <summary>Gets the correlation identifier for the outgoing message.</summary>
 	public string? CorrelationId { get; init; }
 
@@ -20,4 +23,13 @@ public sealed record MessageProperties
 
 	/// <summary>Gets the time-to-live value for the outgoing message.</summary>
 	public TimeSpan? TimeToLive { get; init; }
+
+	/// <summary>Gets the To property for the outgoing message.</summary>
+	public string? To { get; init; }
+
+	/// <summary>Gets the Reply-To property for the outgoing message.</summary>
+	public string? ReplyTo { get; init; }
+
+	/// <summary>Gets the subject for the outgoing message.</summary>
+	public string? Subject { get; init; }
 }

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ReceivedMessageProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ReceivedMessageProperties.cs
@@ -9,6 +9,9 @@ namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <param name="EnqueuedTimeUtc">The enqueue time in UTC.</param>
 /// <param name="ScheduledEnqueueTime">The scheduled enqueue time, if any.</param>
 /// <param name="TimeToLive">The time to live, if any.</param>
+/// <param name="To">The To property, if any.</param>
+/// <param name="ReplyTo">The Reply To property, if any.</param>
+/// <param name="Subject">The subject, if any.</param>
 public sealed record ReceivedMessageProperties(
 	string MessageId,
 	string? PartitionKey,
@@ -17,4 +20,7 @@ public sealed record ReceivedMessageProperties(
 	string? ContentType,
 	DateTimeOffset EnqueuedTimeUtc,
 	DateTimeOffset? ScheduledEnqueueTime,
-	TimeSpan? TimeToLive);
+	TimeSpan? TimeToLive,
+	string? To,
+	string? ReplyTo,
+	string? Subject);

--- a/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Services/ViewerMessageService.cs
@@ -30,6 +30,8 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 			if (!requiresSession)
 				session.ReceiveSessionId = null;
 
+			session.SendResultMessage = null;
+
 			return session.ToViewerState(connection);
 		}
 		finally {
@@ -86,11 +88,10 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 			EntityId entityId = session.SelectedEntityId ?? throw new InvalidOperationException("No entity selected.");
 			EntityProperties entity = connection.GetEntityProperties(entityId);
 
-			ValidateRequiredSessionId(entity, command.MessageProperties);
+			if (entity.RequiresSession && string.IsNullOrWhiteSpace(command.MessageProperties.SessionId))
+				throw new SendMessageValidationException($"A Session ID is required when sending to '{entity.Name}' because the selected entity requires sessions.");
 
 			await connection.SendMessageAsync(entityId, command, operationCancellationToken);
-
-			session.SendResultMessage = BuildSendResultMessage(command.MessageProperties.ContentType, command.MessageProperties.MessageId);
 
 			if (!entity.RequiresSession)
 				session.ReceiveSessionId = null;
@@ -98,22 +99,5 @@ internal sealed class ViewerMessageService(ILogger<ViewerMessageService> logger)
 		finally {
 			session.Gate.Release();
 		}
-	}
-
-	private static void ValidateRequiredSessionId(EntityProperties entity, MessageProperties messageProperties)
-	{
-		if (entity.RequiresSession && string.IsNullOrWhiteSpace(messageProperties.SessionId))
-			throw new SendMessageValidationException($"A Session ID is required when sending to '{entity.Name}' because the selected entity requires sessions.");
-	}
-
-	private static string BuildSendResultMessage(string? sentContentType, string? sentMessageId)
-	{
-		string contentTypeDescription = string.IsNullOrWhiteSpace(sentContentType)
-			? "without a content type"
-			: $"with content type '{sentContentType}'";
-
-		return string.IsNullOrWhiteSpace(sentMessageId)
-			? $"Message sent successfully {contentTypeDescription}."
-			: $"Message '{sentMessageId}' sent successfully {contentTypeDescription}.";
 	}
 }

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -81,27 +81,37 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 		EntityProperties entity = GetEntityProperties(entityId);
 		await using ServiceBusSender sender = GetSender(entity);
 		ServiceBusMessage message = new(command.Body);
-		MessageProperties? messageProperties = command.MessageProperties;
+		MessageProperties messageProperties = command.MessageProperties;
 
-		if (messageProperties is not null) {
-			if (!string.IsNullOrWhiteSpace(messageProperties.MessageId))
-				message.MessageId = messageProperties.MessageId;
+		if (!string.IsNullOrWhiteSpace(messageProperties.MessageId))
+			message.MessageId = messageProperties.MessageId;
 
-			if (!string.IsNullOrWhiteSpace(messageProperties.ContentType))
-				message.ContentType = messageProperties.ContentType;
+		if (!string.IsNullOrWhiteSpace(messageProperties.ContentType))
+			message.ContentType = messageProperties.ContentType;
 
-			if (!string.IsNullOrWhiteSpace(messageProperties.SessionId))
-				message.SessionId = messageProperties.SessionId;
+		if (!string.IsNullOrWhiteSpace(messageProperties.SessionId))
+			message.SessionId = messageProperties.SessionId;
 
-			if (!string.IsNullOrWhiteSpace(messageProperties.CorrelationId))
-				message.CorrelationId = messageProperties.CorrelationId;
+		if (!string.IsNullOrWhiteSpace(messageProperties.PartitionKey))
+			message.PartitionKey = messageProperties.PartitionKey;
 
-			if (messageProperties.ScheduledEnqueueTime is not null)
-				message.ScheduledEnqueueTime = messageProperties.ScheduledEnqueueTime.Value;
+		if (!string.IsNullOrWhiteSpace(messageProperties.CorrelationId))
+			message.CorrelationId = messageProperties.CorrelationId;
 
-			if (messageProperties.TimeToLive is not null)
-				message.TimeToLive = messageProperties.TimeToLive.Value;
-		}
+		if (messageProperties.ScheduledEnqueueTime is not null)
+			message.ScheduledEnqueueTime = messageProperties.ScheduledEnqueueTime.Value;
+
+		if (messageProperties.TimeToLive is not null)
+			message.TimeToLive = messageProperties.TimeToLive.Value;
+
+		if (!string.IsNullOrWhiteSpace(messageProperties.To))
+			message.To = messageProperties.To;
+
+		if (!string.IsNullOrWhiteSpace(messageProperties.ReplyTo))
+			message.ReplyTo = messageProperties.ReplyTo;
+
+		if (!string.IsNullOrWhiteSpace(messageProperties.Subject))
+			message.Subject = messageProperties.Subject;
 
 		foreach (ApplicationProperty property in command.ApplicationProperties) {
 			if (!string.IsNullOrWhiteSpace(property.Key))
@@ -255,7 +265,10 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 			message.ContentType,
 			message.EnqueuedTime,
 			message.ScheduledEnqueueTime != DateTimeOffset.MinValue ? message.ScheduledEnqueueTime : null,
-			message.TimeToLive != TimeSpan.MaxValue ? message.TimeToLive : null);
+			message.TimeToLive != TimeSpan.MaxValue ? message.TimeToLive : null,
+			message.To,
+			message.ReplyTo,
+			message.Subject);
 
 		return new ReceivedMessage(
 			message.Body.ToString(),

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.45.0</Version>
+		<Version>0.47.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>

--- a/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
+++ b/src/SolidCode.Aspire.Hosting.ServiceBusViewer/README.md
@@ -154,6 +154,7 @@ builder.AddServiceBusViewer("servicebusviewer")
 
 ## Notes
 
+- The package version is aligned with the Aspire version it targets, and future releases will continue to carry the same version number as their target Aspire release.
 - The package is container-focused.
 - `.WithServiceBusEmulatorReference(...)` defaults to endpoint names `emulator` and `emulatorhealth`, matching the current Aspire Azure Service Bus emulator integration.
 - You can override those endpoint names when your AppHost uses a custom emulator resource shape.

--- a/src/SolidCode.Aspire.Hosting.ServiceBusViewer/SolidCode.Aspire.Hosting.ServiceBusViewer.csproj
+++ b/src/SolidCode.Aspire.Hosting.ServiceBusViewer/SolidCode.Aspire.Hosting.ServiceBusViewer.csproj
@@ -9,8 +9,8 @@
 		<Product>ServiceBusViewer</Product>
 		<Description>A reusable .NET Aspire hosting integration for the Service Bus Viewer container.</Description>
 		<Authors>Andrey Veselov</Authors>
-		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
-		<Version>0.1.0</Version>
+		<Copyright>Copyright © 2026 Andrey Veselov</Copyright>
+		<Version>13.5.2</Version>
 
 		<PackageId>SolidCode.Aspire.Hosting.ServiceBusViewer</PackageId>
 		<Title>Aspire Hosting for Service Bus Viewer</Title>
@@ -44,7 +44,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Aspire.Hosting" Version="13.4.6" />
+		<PackageReference Include="Aspire.Hosting" Version="13.5.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Add optional To, Reply To, Subject, and Partition Key fields in the Send Message window, persisted on the outgoing message and shown in received/peeked message details
- Add Advanced toggle in the send window header, saved in a browser cookie and defaulting to off
- Show partition key under the entity name in the Peeked Messages table for partitioned queues and topics
- Rename "Application Properties" sections to "Custom Properties"
- Skip Diagnostic-Id application property when pasting a message from clipboard into the send window
- Keep the Message ID duplicate-detection warning always visible on entities with duplicate detection enabled and fix info/warning styling semantics
- Stretch the payload editor to match the properties column
- Upgrade Aspire SDK and hosting packages to 13.5.2
- Add aspire agent skill docs
- Bump version to 0.47.0