### PR TITLE
feat: display per-message delivery count in the viewer

### DIFF
--- a/.agents/specs/PROJECT_DECISIONS.md
+++ b/.agents/specs/PROJECT_DECISIONS.md
@@ -1,5 +1,9 @@
 # Project Decisions
 
+## 2026-08-23: Aspire package versioning policy
+
+- The `SolidCode.Aspire.Hosting.ServiceBusViewer` package version is aligned with the Aspire version it is built against, and future releases will continue to carry the same version number as their target Aspire release.
+
 ## 2026-08-16: Empty receive timeout behavior
 
 - Receive operations treat an empty queue or subscription as a short-poll scenario and return after about one second instead of inheriting the Azure Service Bus default wait timeout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Service Bus Viewer Version History
 
-## 0.47.0 (2026-08-23)
+## 0.48.0 (2026-08-23)
 
+- **Added:** Per-message **Delivery Count** based on `SystemProperties.DeliveryCount` as reported by Azure Service Bus, shown as a column in the Peeked Messages list and in the Last Received Message details, so redelivered messages are visible without opening each one.
 - **Added:** Optional **To**, **Reply To**, **Subject**, and **Partition Key** fields in the Send Message window, with the values sent on the outgoing message and displayed in received and expanded peeked message details.
 - **Added:** **Advanced** toggle in the Send Message header that shows or hides the new fields; the choice is saved in a browser cookie and defaults to off.
+- **Changed:** The delivery count is display-only: it does not affect receiving, completing, or dead-lettering messages and adds no badges, warnings, or color coding.
 - **Changed:** The Peeked Messages table shows the partition key as a sub-value under the entity name for partitioned queues and topics.
 - **Changed:** Renamed the **Application Properties** section in the send and receive views to **Custom Properties**.
 - **Changed:** The Aspire AppHost and the `SolidCode.Aspire.Hosting.ServiceBusViewer` support library are now built against Aspire 13.5.2.

--- a/README.md
+++ b/README.md
@@ -94,11 +94,14 @@ Tabs that share the same browser cookie jar also share the same Service Bus View
 
 ## Version history
 
-## 0.47.0 (2026-08-23)
+## 0.48.0 (2026-08-23)
 
+- **Added:** Per-message Delivery Count based on SystemProperties.DeliveryCount as reported by Azure Service Bus, shown as a column in the Peeked Messages list and in the Last Received Message details.
 - **Added:** Optional To, Reply To, Subject, and Partition Key fields in the Send Message window, with the values sent on the outgoing message and displayed in received and expanded peeked message details.
 - **Added:** Advanced toggle in the Send Message header that shows or hides the new fields; the choice is saved in a browser cookie and defaults to off.
+- **Changed:** The delivery count is display-only: it does not affect receiving, completing, or dead-lettering messages and adds no badges, warnings, or color coding.
 - **Changed:** The Peeked Messages table shows the partition key as a sub-value under the entity name for partitioned queues and topics.
+- **Changed:** Renamed the Application Properties section in the send and receive views to Custom Properties.
 - **Changed:** The Aspire AppHost and the `SolidCode.Aspire.Hosting.ServiceBusViewer` support library are now built against Aspire 13.5.2.
 - **Changed:** The `SolidCode.Aspire.Hosting.ServiceBusViewer` package version is now aligned with the Aspire version it targets, and future releases will continue to carry the same version number as their target Aspire release.
 - **Changed:** Paste From Clipboard now skips the Diagnostic-Id application property when loading a copied message into the send window.

--- a/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
+++ b/src/ServiceBusViewer.Web/src/pages/ViewerPage.tsx
@@ -171,7 +171,7 @@ export function ViewerPage() {
 	const showPartitionKey = currentViewer?.messages.some((message) =>
 		Boolean(message.properties.partitionKey),
 	) ?? false;
-	const peekedMessageColumnCount = 5 + (showScheduledEnqueue ? 1 : 0) + (showPartitionKey ? 1 : 0);
+	const peekedMessageColumnCount = 6 + (showScheduledEnqueue ? 1 : 0) + (showPartitionKey ? 1 : 0);
 
 	const handleDisconnect = async () => {
 		await runAction('disconnect', async () => {
@@ -421,7 +421,7 @@ export function ViewerPage() {
 								<div className="p-4 lg:p-6">
 									{currentViewer?.displayedMessage ? (
 										<>
-											<div className="grid gap-4 border-b border-dashed border-slate-200 pb-4 dark:border-slate-800 lg:grid-cols-2 xl:grid-cols-4">
+											<div className="grid gap-4 border-b border-dashed border-slate-200 pb-4 dark:border-slate-800 lg:grid-cols-2 xl:grid-cols-5">
 												<div>
 													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
 														Enqueued Time
@@ -452,6 +452,14 @@ export function ViewerPage() {
 													</div>
 													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
 														{formatNullable(currentViewer.displayedMessage.properties.sessionId)}
+													</div>
+												</div>
+												<div>
+													<div className="text-[11px] font-bold uppercase tracking-[0.18em] text-slate-400 dark:text-slate-500">
+														Delivery Count
+													</div>
+													<div className="mt-1 font-mono text-xs text-slate-700 dark:text-slate-200">
+														{currentViewer.displayedMessage.properties.deliveryCount}
 													</div>
 												</div>
 											</div>
@@ -525,6 +533,7 @@ export function ViewerPage() {
 													<th className="px-4 py-3 font-medium">Message ID</th>
 													{showPartitionKey && <th className="px-4 py-3 font-medium">Partition Key</th>}
 													<th className="px-4 py-3 font-medium">Session</th>
+													<th className="px-4 py-3 font-medium">Delivery Count</th>
 													<th className="px-4 py-3 font-medium">Enqueued Time / TTL</th>
 													{showScheduledEnqueue && <th className="px-4 py-3 font-medium">Scheduled Enqueue</th>}
 													<th className="px-4 py-3 font-medium">Content Type</th>
@@ -558,6 +567,9 @@ export function ViewerPage() {
 																)}
 																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
 																	{formatNullable(message.properties.sessionId, 'No session')}
+																</td>
+																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
+																	{message.properties.deliveryCount}
 																</td>
 																<td className="px-4 py-3 text-xs text-slate-600 dark:text-slate-300">
 																	{formatDateTimeShort(message.properties.enqueuedTimeUtc)}

--- a/src/ServiceBusViewer.Web/src/types/serviceBus.ts
+++ b/src/ServiceBusViewer.Web/src/types/serviceBus.ts
@@ -19,6 +19,7 @@ export interface ReceivedMessagePropertiesDto {
 	sessionId: string | null;
 	correlationId: string | null;
 	contentType: string | null;
+	deliveryCount: number;
 	enqueuedTimeUtc: string;
 	scheduledEnqueueTime: string | null;
 	timeToLive: string | null;

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessage.cs
@@ -27,6 +27,7 @@ public static class ReceivedMessageExtensions
 					message.Properties.SessionId,
 					message.Properties.CorrelationId,
 					message.Properties.ContentType,
+					message.Properties.DeliveryCount,
 					message.Properties.EnqueuedTimeUtc.ToString("O", CultureInfo.InvariantCulture),
 					message.Properties.ScheduledEnqueueTime?.ToString("O", CultureInfo.InvariantCulture),
 					message.Properties.TimeToLive?.ToString("c", CultureInfo.InvariantCulture),

--- a/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
+++ b/src/ServiceBusViewer/Api/Models/ReceivedMessageProperties.cs
@@ -6,6 +6,7 @@ namespace ServiceBusViewer.Api.Models;
 /// <param name="SessionId">Session id if present.</param>
 /// <param name="CorrelationId">Correlation id if present.</param>
 /// <param name="ContentType">Content type if present.</param>
+/// <param name="DeliveryCount">Delivery count reported by Service Bus.</param>
 /// <param name="EnqueuedTimeUtc">Enqueued time in UTC (ISO-8601).</param>
 /// <param name="ScheduledEnqueueTime">Scheduled enqueue time (ISO-8601) or null.</param>
 /// <param name="TimeToLive">Time-to-live as string or null.</param>
@@ -18,6 +19,7 @@ public sealed record ReceivedMessageProperties(
 	string? SessionId,
 	string? CorrelationId,
 	string? ContentType,
+	int DeliveryCount,
 	string EnqueuedTimeUtc,
 	string? ScheduledEnqueueTime,
 	string? TimeToLive,

--- a/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ReceivedMessageProperties.cs
+++ b/src/ServiceBusViewer/Business/Viewer/Contracts/ServiceBus/ReceivedMessageProperties.cs
@@ -6,6 +6,7 @@ namespace ServiceBusViewer.Business.Viewer.Contracts.ServiceBus;
 /// <param name="SessionId">The session id, if any.</param>
 /// <param name="CorrelationId">The correlation id, if any.</param>
 /// <param name="ContentType">The content type, if any.</param>
+/// <param name="DeliveryCount">The number of delivery attempts reported by Service Bus.</param>
 /// <param name="EnqueuedTimeUtc">The enqueue time in UTC.</param>
 /// <param name="ScheduledEnqueueTime">The scheduled enqueue time, if any.</param>
 /// <param name="TimeToLive">The time to live, if any.</param>
@@ -18,6 +19,7 @@ public sealed record ReceivedMessageProperties(
 	string? SessionId,
 	string? CorrelationId,
 	string? ContentType,
+	int DeliveryCount,
 	DateTimeOffset EnqueuedTimeUtc,
 	DateTimeOffset? ScheduledEnqueueTime,
 	TimeSpan? TimeToLive,

--- a/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
+++ b/src/ServiceBusViewer/Infrastructure/ServiceBus/ServiceBusConnection.cs
@@ -263,6 +263,7 @@ internal sealed class ServiceBusConnection : IServiceBusConnection
 			message.SessionId,
 			message.CorrelationId,
 			message.ContentType,
+			message.DeliveryCount,
 			message.EnqueuedTime,
 			message.ScheduledEnqueueTime != DateTimeOffset.MinValue ? message.ScheduledEnqueueTime : null,
 			message.TimeToLive != TimeSpan.MaxValue ? message.TimeToLive : null,

--- a/src/ServiceBusViewer/ServiceBusViewer.csproj
+++ b/src/ServiceBusViewer/ServiceBusViewer.csproj
@@ -6,7 +6,7 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<Product>ServiceBusViewer</Product>
-		<Version>0.47.0</Version>
+		<Version>0.48.0</Version>
 		<Authors>Andrey Veselov</Authors>
 		<Copyright>Copyright © 2025-2026 Andrey Veselov</Copyright>
 		<Description>HTTP API for the Service Bus Viewer.</Description>


### PR DESCRIPTION
feat: display per-message delivery count in the viewer

Add a Delivery Count sourced from SystemProperties.DeliveryCount shown as a column in the Peeked Messages list and in the Last Received Message details.
